### PR TITLE
[QOL-7971] fix loading of groups when editing datasets

### DIFF
--- a/ckanext/publications_qld_theme/templates/package/group_list.html
+++ b/ckanext/publications_qld_theme/templates/package/group_list.html
@@ -5,13 +5,13 @@
   <h2 class="hide-heading">{{ _('Categories') }}</h2>
 
   {% if h.check_access('package_update', {'id':c.pkg_dict.id }) %}
-    {% set groups = h.get_all_groups() %}
+    {% set groups = h.groups_available() %}
     {% if groups %}
       <form class="add-to-group" method="post">
         <div class="form-group">
           <select id="field-add_group" class="form-control" name="group_added">
             {% for option in groups %}
-              <option value="{{ option[0] }}"> {{ option[1] }}</option>
+              <option value="{{ option.id }}"> {{ option.display_name }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
- use the 'groups_available' helper so we don't truncate and don't get groups we can't access