### PR TITLE
[QOL-4746] show CKAN version in the page header for sysadmins only

### DIFF
--- a/ckanext/publications_qld_theme/templates/header.html
+++ b/ckanext/publications_qld_theme/templates/header.html
@@ -7,6 +7,7 @@
     <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
       <ul class="unstyled">
         {% block header_account_logged %} {% if c.userobj.sysadmin %}
+        <li>CKAN {{ h.ckan_version() }}</li>
         <li>
           <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
             <i class="fa fa-gavel" aria-hidden="true"></i>


### PR DESCRIPTION
- this can replace it in the publicly visible status_show API