### PR TITLE
[QOL-8104] move presigned indexing block inside the prod block

### DIFF
--- a/ckanext/publications_qld_theme/templates/robots.txt
+++ b/ckanext/publications_qld_theme/templates/robots.txt
@@ -51,6 +51,8 @@ Disallow: /tr/
 Disallow: /uk_UA/
 Disallow: /zh_CN/
 Disallow: /zh_TW/
+# presigned S3 URLs that are only temporary
+Disallow: /ckan-*-attachments-*/
 Crawl-Delay: 10
 {% endraw %}
 {% else %}
@@ -72,6 +74,4 @@ Allow: /api/
 {% endraw %}
 {% endif %}
 
-# presigned S3 URLs that are only temporary
-Disallow: /ckan-*-attachments-*/
 {% endblock %}


### PR DESCRIPTION
- non-prod environments disallow everything anyway