### PR TITLE
QOL-8594 prepare for CKAN 2.9

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -112,7 +112,7 @@ commands:
   test-unit:
     usage: Run unit tests.
     cmd: |
-      ahoy cli 'nosetests --with-pylons=${CKAN_INI}' || \
+      ahoy cli 'pytest --ckan-ini=${CKAN_INI}' || \
       [ "${ALLOW_UNIT_FAIL:-0}" -eq 1 ]
 
   test-bdd:

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -118,8 +118,24 @@ commands:
   test-bdd:
     usage: Run BDD tests.
     cmd: |
-      ahoy cli "behave ${*:-test/features}" || \
+      ahoy start-mailmock &
+      sleep 5 &&
+      ahoy cli "behave -k ${*:-test/features}" --tags @smoke && \
+      ahoy cli "behave --no-capture ${*:-test/features}" || \
       [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      ahoy stop-mailmock
+
+  start-mailmock:
+    usage: Starts email mock server used for email BDD tests
+    cmd: |
+      ahoy title 'Starting mailmock'
+      ahoy cli 'mailmock -p 8025 -o ${APP_DIR}/test/emails' # for debugging mailmock email output remove --no-stdout
+
+  stop-mailmock:
+    usage: Stops email mock server used for email BDD tests
+    cmd: |
+      ahoy title 'Stopping mailmock'
+      ahoy cli "killall -2 mailmock"
 
   # Utilities.
   title:

--- a/.docker/Dockerfile.ckan
+++ b/.docker/Dockerfile.ckan
@@ -2,7 +2,7 @@ FROM amazeeio/python:2.7-ckan-21.8.0
 
 ARG SITE_URL=http://ckan:3000/
 ARG CKAN_REPO=qld-gov-au/ckan
-ARG CKAN_VERSION=2.8.8-qgov.5
+ARG CKAN_VERSION=ckan-2.8.8-qgov.5
 ENV SITE_URL="${SITE_URL}"
 ENV VENV_DIR=/app/ckan/default
 ENV APP_DIR=/app
@@ -20,7 +20,7 @@ RUN apk add --no-cache curl build-base \
 
 RUN . ${VENV_DIR}/bin/activate \
     && pip install setuptools==36.1 \
-    && pip install -e "git+https://github.com/${CKAN_REPO}.git@ckan-${CKAN_VERSION}#egg=ckan" \
+    && pip install -e "git+https://github.com/${CKAN_REPO}.git@${CKAN_VERSION}#egg=ckan" \
     && sed -i "s/psycopg2==2.4.5/psycopg2==2.7.7/g" "${VENV_DIR}/src/ckan/requirements.txt" \
     && ((test -f "${VENV_DIR}/src/ckan/requirements-py2.txt" && \
         pip install -r "${VENV_DIR}/src/ckan/requirements-py2.txt") || \

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -109,6 +109,62 @@ package_owner_org_update=$( \
 )
 echo ${package_owner_org_update}
 
+echo "Updating organisation_admin to have admin privileges in the department-of-health Organisation:"
+organisation_admin_update=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "id=department-of-health&username=organisation_admin&role=admin" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${organisation_admin_update}
+
+echo "Updating publisher to have editor privileges in the department-of-health Organisation:"
+publisher_update=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "id=department-of-health&username=editor&role=editor" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${publisher_update}
+
+echo "Updating foodie to have admin privileges in the food-standards-agency Organisation:"
+foodie_update=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "id=food-standards-agency&username=foodie&role=admin" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${foodie_update}
+
+echo "Creating non-organisation group:"
+group_create=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "name=silly-walks" \
+    ${CKAN_ACTION_URL}/group_create
+)
+echo ${group_create}
+
+echo "Updating group_admin to have admin privileges in the silly-walks group:"
+group_admin_update=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "id=silly-walks&username=group_admin&role=admin" \
+    ${CKAN_ACTION_URL}/group_member_create
+)
+echo ${group_admin_update}
+
+echo "Updating walker to have editor privileges in the silly-walks group:"
+walker_update=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "id=silly-walks&username=walker&role=editor" \
+    ${CKAN_ACTION_URL}/group_member_create
+)
+echo ${walker_update}
+
+echo "Creating gazette group:"
+group_create=$( \
+    curl -LsH "Authorization: ${API_KEY}" \
+    --data "name=gazettes-test" \
+    ${CKAN_ACTION_URL}/group_create
+)
+echo ${group_create}
+
 if [ "$VENV_DIR" != "" ]; then
   deactivate
 fi

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -78,6 +78,17 @@ ckan_cli create-test-data hierarchy
 # Creating basic test data which has datasets with resources
 ckan_cli create-test-data basic
 
+add_user_if_needed organisation_admin "Organisation Admin" organisation_admin@localhost
+add_user_if_needed editor "Publisher" publisher@localhost
+add_user_if_needed foodie "Foodie" foodie@localhost
+add_user_if_needed group_admin "Group Admin" group_admin@localhost
+add_user_if_needed walker "Walker" walker@localhost
+
+# Create publishing standards dataset
+curl -LsH "Authorization: ${API_KEY}" \
+    --data "name=publishing-standards-publications-qld-gov-au&owner_org=${TEST_ORG_ID}" \
+    ${CKAN_ACTION_URL}/package_create
+
 # Datasets need to be assigned to an organisation
 
 echo "Assigning test Datasets to Organisation..."

--- a/.docker/scripts/doctor.sh
+++ b/.docker/scripts/doctor.sh
@@ -75,7 +75,7 @@ main() {
     #      - container:amazeeio-ssh-agent
     #    ```
     # 4. When CLI container starts, the volume is mounted and an entrypoint script
-    #    adds SHH key into agent.
+    #    adds SSH key into agent.
     #    @see https://github.com/amazeeio/lagoon/blob/master/images/php/cli/10-ssh-agent.sh
     #
     #  Running `ssh-add -L` within CLI container should show that the SSH key

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -159,6 +159,10 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 
 
 ## Email settings
+# If 'smtp.test_server' is configured we assume we're running tests,
+# and don't use the smtp.server, starttls, user, password etc. options.
+smtp.test_server = localhost:8025
+smtp.mail_from = info@test.ckan.net
 
 #email_to = errors@example.com
 #error_email_from = ckan-errors@example.com

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -97,8 +97,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
-# @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext
+ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext resource_type_validation
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.8.8-qgov.5]
+        ckan-version: [ckan-2.8.8-qgov.5, ckan-2.9.4-qgov.4]
 
     name: Continuous Integration build on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
       - name: Retrieve screenshots
         if: failure()
         run: .circleci/process-artifacts.sh
-        timeout-minutes: 3
+        timeout-minutes: 1
 
       - name: Upload screenshots
         if: failure()

--- a/ckanext/publications_qld_theme/plugin.py
+++ b/ckanext/publications_qld_theme/plugin.py
@@ -50,10 +50,13 @@ def is_request_for_resource():
     eg. /dataset/example/resource/b33a702a-f162-44a8-aad9-b9e630a8f56e
     :return:
     """
-    original_request = request.environ.get('pylons.original_request')
-    if original_request:
-        return re.search(r"/dataset/\S+/resource/\S+",
-                         original_request.path)
+    if request:
+        path = request.path
+        if hasattr(request, 'environ'):
+            original_request = request.environ.get('pylons.original_request')
+            if original_request:
+                path = original_request.path
+        return re.search(r"/dataset/\S+/resource/\S+", path)
     return False
 
 

--- a/ckanext/publications_qld_theme/templates/group/snippets/group_item.html
+++ b/ckanext/publications_qld_theme/templates/group/snippets/group_item.html
@@ -30,7 +30,7 @@ Example:
     {% endblock %}
     {% block datasets %}
       <td>
-        {% if h.check_access('member_delete', group) and c.controller in ['package', 'dataset'] and c.action in ['groups']
+        {% if h.check_access('member_delete', group) and h.current_url().startswith('/dataset/groups')
             and (
                 c.pkg_dict is none
                 or c.pkg_dict.id is none

--- a/ckanext/publications_qld_theme/templates/group/snippets/group_list.html
+++ b/ckanext/publications_qld_theme/templates/group/snippets/group_list.html
@@ -11,19 +11,19 @@ Example:
 {% block group_list %}
 <div class="table-responsive">
   <table class="table table-striped" width="100%">
-  	<thead>
-  		<tr>
-  			<th>Title</th>
-  			<th width="80px">{% if c.controller in ['package', 'dataset'] and c.action in ['groups'] %}&nbsp;{% else %}Datasets{% endif %}</th>
-  		</tr>
-  	</thead>
-  	<tbody>
-	{% block group_list_inner %}
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th width="80px">{% if h.current_url().startswith('/dataset/groups/' %}&nbsp;{% else %}Datasets{% endif %}</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% block group_list_inner %}
   {% for group in groups %}
     {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
   {% endfor %}
   {% endblock %}
-  	</tbody>
+    </tbody>
   </table>
 </div>
 

--- a/ckanext/publications_qld_theme/templates/header.html
+++ b/ckanext/publications_qld_theme/templates/header.html
@@ -59,9 +59,6 @@
 </div>
 {% endblock %}
 <header class="navbar navbar-static-top masthead">
-  {% block header_debug %} {% if g.debug and not g.debug_supress_header %}
-  <div class="debug">Controller : {{ c.controller }}<br/>Action : {{ c.action }}</div>
-  {% endif %} {% endblock %}
   <div class="container">
     <button
       data-target="#main-navigation-toggle"
@@ -91,11 +88,11 @@
       <nav class="section navigation">
         <ul class="nav nav-pills">
           {% block header_site_navigation_tabs %}
-          {% if c.controller == 'package' and c.id == 'publishing-standards-publications-qld-gov-au' %}
+          {% if h.current_url().startswith('/dataset/publishing-standards-publications-qld-gov-au') %}
             {% set standards_active=True %}
-          {% elif c.controller in ['package', 'group'] and c.id.startswith('gazettes-') %}
+          {% elif h.current_url().startswith('/dataset/gazettes-') or h.current_url().startswith('/group/gazettes-') %}
             {% set gazettes_active=True %}
-          {% elif c.controller == 'organization' %}
+          {% elif h.current_url().startswith('/organization') %}
             {% set organization_active=True %}
           {% elif h.current_url() != '/' %}
             {% set publications_active=True %}

--- a/ckanext/publications_qld_theme/templates/home/index.html
+++ b/ckanext/publications_qld_theme/templates/home/index.html
@@ -1,5 +1,10 @@
 {% extends "page.html" %}
 {% set homepage_style = ( g.homepage_style or '1' ) %}
+{% if h.ckan_version() > '2.9' %}
+  {% set org_route_name = 'organization.read' %}
+{% else %}
+  {% set org_route_name = 'organization_read' %}
+{% endif %}
 
 {% block subtitle %}{{ _("Welcome") }}{% endblock %}
 
@@ -81,7 +86,7 @@
                             <!-- noindex -->
                             {% for group, num_packages in h.top_organisations(limit=5) %}
                                 {% if num_packages > 0 and (group.title or group.name) %}
-                                    <li>{{ h.link_to(group.title or group.name, h.url_for(controller='organization', action='read', id=group.name)) }} ({{ num_packages }})</li>
+                                    <li>{% link_for group.title or group.name, named_route=org_route_name, id=group.name %} ({{ num_packages }})</li>
                                 {% endif %}
                             {% endfor %}
                             <!-- endnoindex -->

--- a/ckanext/publications_qld_theme/templates/snippets/organization.html
+++ b/ckanext/publications_qld_theme/templates/snippets/organization.html
@@ -4,6 +4,20 @@
 
 {% endblock %}
 
+{% if h.ckan_version() > '2.9' %}
+  {% set org_about='organization.about' %}
+{% else %}
+  {% set org_about='organization_about' %}
+{% endif %}
+{% block description %}
+    {% if organization.description %}
+        <p>
+        {{ h.markdown_extract(organization.description, 180) }}
+        {% link_for _('read more'), named_route=org_about, id=organization.name %}
+        </p>
+    {% endif %}
+{% endblock %}
+
 {% block package_openness %}
 
 {% endblock %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,16 @@
 behave==1.2.6
 behaving==2.0.0
 Appium-Python-Client<=0.52
+ckanapi==4.3
+ckantoolkit>=0.0.4
+factory-boy==2.12.0
 flake8==3.8.3
-nose==1.3.7
+mock
+pytest-ckan
 six>=1.13.0
 splinter>=0.13.0,<0.17
 
-git+https://github.com/ckan/ckanapi@ckanapi-4.3#egg=ckanapi
-git+https://github.com/ckan/ckantoolkit@release-0.0.4#egg=ckantoolkit
--e git+https://github.com/qld-gov-au/ckan-ex-qgov.git@4.0.0#egg=ckanext-qgov
+-e git+https://github.com/qld-gov-au/ckan-ex-qgov.git@4.0.2#egg=ckanext-qgov
+-e git+https://github.com/qld-gov-au/ckanext-csrf-filter.git@1.1.2#egg=ckanext-csrf-filter
+-e git+https://github.com/qld-gov-au/ckanext-resource-type-validation.git@1.0.2#egg=ckanext-resource-type-validation
 

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,21 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 setup(
-    name='''ckanext-publications-qld-theme''',
+    name='ckanext-publications-qld-theme',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
     version='0.0.1',
 
-    description='''Custom extension for Publications QLD''',
-    long_description='''''',
+    description='Custom extension for Publications QLD',
+    long_description='',
 
     # The project's main homepage.
     url='https://github.com/qld-gov-au/ckanext-publications-qld-theme',
 
     # Author details
-    author='Salsa Digital',
+    author='Queensland Government and Salsa Digital',
     author_email='',
 
     # Choose your license
@@ -47,7 +47,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    # namespace_packages=['ckanext'],
+    namespace_packages=['ckanext'],
 
     install_requires=[
         # CKAN extensions should not list dependencies here, but in a separate

--- a/test/features/config.feature
+++ b/test/features/config.feature
@@ -1,9 +1,10 @@
 @config
 Feature: Config
 
-    Scenario: Assert that CSS configuration values are removed
+    Scenario: Assert that configuration values are customised
         Given "SysAdmin" as the persona
         When I log in and go to admin config page
         Then I should see "Intro Text"
+        And I should see an element with id "field-ckanext.data_qld.excluded_display_name_words"
         And I should not see an element with id "field-ckan-main-css"
         And I should not see an element with id "field-ckan-site-custom-css"

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -1,39 +1,103 @@
 @publications-qld-theme
 Feature: Publications QLD Theme
 
-       Scenario: Lato font is implemented on homepage
-              When I go to homepage
-              Then I should see an element with xpath "//link[contains(@href,'https://fonts.googleapis.com/css?family=Lato')]"
+    Scenario: Lato font is implemented on homepage
+        When I go to homepage
+        Then I should see an element with xpath "//link[contains(@href,'https://fonts.googleapis.com/css?family=Lato')]"
 
-       Scenario: Organisation is in fact spelled Organisation (as opposed to Organization)
-              When I go to organisation page
-              Then I should not see "Organization"
+    Scenario: Organisation is in fact spelled Organisation (as opposed to Organization)
+        When I go to organisation page
+        Then I should see "Organisation"
+        And I should not see "Organization"
 
-       Scenario: Explore button does not exist on dataset detail page
-              When I go to dataset page
-              And I click the link with text that contains "A Wonderful Story"
-              Then I should not see "Explore"
+    Scenario: When I create an organisation without a description, the display should not mention its absence
+        Given "SysAdmin" as the persona
+        When I log in
+        And I go to organisation page
+        And I click the link with text that contains "Add Organisation"
+        Then I should see "Create an Organisation"
+        When I fill in "title" with "Org without description"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
+        Then I should see "Org without description"
+        And I should see "No datasets found"
+        And I should not see "There is no description"
 
-       Scenario: Explore button does not exist on dataset detail page
-              When I go to organisation page
-              Then I should see "Organisations are Queensland Government departments, other agencies or legislative entities responsible for publishing open data on this portal."
+    Scenario: When I create an organisation with a description, there should be a Read More link
+        Given "SysAdmin" as the persona
+        When I log in
+        And I go to organisation page
+        And I click the link with text that contains "Add Organisation"
+        Then I should see "Create an Organisation"
+        When I fill in "title" with "Org with description"
+        And I fill in "description" with "Some description or other"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
+        Then I should see "Org with description"
+        And I should see "No datasets found"
+        And I should see "Some description or other"
+        And I should see an element with xpath "//a[string() = 'read more' and contains(@href, '/organization/about/org-with-description')]"
 
-      Scenario: Register user password must be 10 characters or longer
-              When I go to register page
-              And I fill in "name" with "name"
-              And I fill in "fullname" with "fullname"
-              And I fill in "email" with "email@test.com"
-              And I fill in "password1" with "pass"
-              And I fill in "password2" with "pass"
-              And I press "Create Account"
-              Then I should see "Password: Your password must be 10 characters or longer"
+    Scenario: Explore button does not exist on dataset detail page
+        When I go to dataset page
+        And I click the link with text that contains "A Wonderful Story"
+        Then I should not see "Explore"
 
-       Scenario: Register user password must contain at least one number, lowercase letter, capital letter, and symbol
-              When I go to register page
-              And I fill in "name" with "name"
-              And I fill in "fullname" with "fullname"
-              And I fill in "email" with "email@test.com"
-              And I fill in "password1" with "password1234"
-              And I fill in "password2" with "password1234"
-              And I press "Create Account"
-              Then I should see "Password: Must contain at least one number, lowercase letter, capital letter, and symbol"
+    Scenario: Explore button does not exist on dataset detail page
+        When I go to organisation page
+        Then I should see "Organisations are Queensland Government departments, other agencies or legislative entities responsible for publishing open data on this portal."
+
+    Scenario: Register user password must be 10 characters or longer
+        When I go to register page
+        And I fill in "name" with "name"
+        And I fill in "fullname" with "fullname"
+        And I fill in "email" with "email@test.com"
+        And I fill in "password1" with "pass"
+        And I fill in "password2" with "pass"
+        And I press "Create Account"
+        Then I should see "Password: Your password must be 10 characters or longer"
+
+    Scenario: Register user password must contain at least one number, lowercase letter, capital letter, and symbol
+        When I go to register page
+        And I fill in "name" with "name"
+        And I fill in "fullname" with "fullname"
+        And I fill in "email" with "email@test.com"
+        And I fill in "password1" with "password1234"
+        And I fill in "password2" with "password1234"
+        And I press "Create Account"
+        Then I should see "Password: Must contain at least one number, lowercase letter, capital letter, and symbol"
+
+    Scenario: Menu items are present and correct
+        When I go to "/dataset"
+        Then I should see an element with xpath "//li[contains(@class, 'active')]/a[contains(string(), 'Publication') and (@href='/dataset' or @href='/dataset/')]"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Organisations') and @href='/organization']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Gazettes') and @href='/gazettes-current']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Contact') and @href='https://www.qld.gov.au/contact-us']"
+
+        When I press the element with xpath "//a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"
+        Then I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Publication') and (@href='/dataset' or @href='/dataset/')]"
+        And I should see an element with xpath "//li[contains(@class, 'active')]/a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Organisations') and @href='/organization']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Gazettes') and @href='/gazettes-current']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Contact') and @href='https://www.qld.gov.au/contact-us']"
+
+        When I press the element with xpath "//a[contains(string(), 'Organisations') and @href='/organization']"
+        Then I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Publication') and (@href='/dataset' or @href='/dataset/')]"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"
+        And I should see an element with xpath "//li[contains(@class, 'active')]/a[contains(string(), 'Organisations') and @href='/organization']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Gazettes') and @href='/gazettes-current']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Contact') and @href='https://www.qld.gov.au/contact-us']"
+
+        When I go to "/group/gazettes-test"
+        Then I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Publication') and (@href='/dataset' or @href='/dataset/')]"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Organisations') and @href='/organization']"
+        And I should see an element with xpath "//li[contains(@class, 'active')]/a[contains(string(), 'Gazettes') and @href='/gazettes-current']"
+        And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Contact') and @href='https://www.qld.gov.au/contact-us']"
+
+    Scenario: When I encounter a 'resource not found' error page, it has a custom message
+        When I go to "/dataset/nonexistent/resource/nonexistent"
+        Then I should see "Sorry, the page you were looking for could not be found."
+
+        When I go to "/nonexistent"
+        Then I should see an element with xpath "//div[contains(string(), 'was not found') or contains(string(), 'could not be found')]"
+        And I should not see "Sorry, the page you were looking for could not be found."

--- a/test/features/dataset_deletion.feature
+++ b/test/features/dataset_deletion.feature
@@ -11,7 +11,7 @@ Feature: Dataset deletion
         Then I select "False" from "private"
         Then I fill in "version" with "1"
         Then I fill in "author_email" with "test@test.com"
-        Then I press "save"
+        And I press the element with xpath "//form[contains(@class, 'dataset-form')]//button[contains(@class, 'btn-primary')]"
         And I wait for 10 seconds
         Then I execute the script "document.getElementById('field-image-url').value='https://example.com'"
         Then I fill in "name" with "res1"
@@ -22,11 +22,10 @@ Feature: Dataset deletion
 
         When I go to "/dataset/edit/dataset-deletion"
         Then I press the element with xpath "//a[string()='Delete' and @data-module='confirm-action']"
-        And I wait for 5 seconds
         Then I press the element with xpath "//div[@class='modal-footer']//button[@class='btn btn-primary']"
         And I wait for 5 seconds
         Then I should see "Dataset has been deleted"
         And I should not see "Dataset deletion"
         When I go to "/ckan-admin/trash"
         Then I should see "Dataset deletion"
-        Then I press the element with xpath "//button[@name='purge-packages']"
+        Then I press the element with xpath "//form[contains(@id, 'form-purge-package')]//*[contains(text(), 'Purge')]"

--- a/test/features/datasets.feature
+++ b/test/features/datasets.feature
@@ -1,0 +1,23 @@
+Feature: Dataset APIs
+
+    Scenario: Creative Commons BY-NC-SA 4.0 licence is an option for datasets
+        Given "SysAdmin" as the persona
+        When I log in
+        And I edit the "warandpeace" dataset
+        Then I should see an element with xpath "//option[@value='cc-by-nc-sa-4']"
+
+    @smoke
+    Scenario: As a user with publishing privileges, I can create a dataset
+        Given "TestOrgEditor" as the persona
+        When I log in
+        And I visit "/dataset/new"
+        And I fill in title with random text
+        And I fill in "notes" with "Testing dataset creation"
+        And I fill in "version" with "1.0"
+        And I fill in "author_email" with "test@me.com"
+        And I press "Add Data"
+        And I press the element with xpath "//form[@id='resource-edit']//a[string() = 'Link']"
+        And I fill in "name" with "Test"
+        And I fill in "url" with "https://example.com"
+        And I press the element with xpath "//button[contains(string(), 'Finish')]"
+        Then I should see "Testing dataset creation"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -26,6 +26,31 @@ PERSONAS = {
         'email': u'',
         'password': u''
     },
+    'Organisation Admin': {
+        'name': u'organisation_admin',
+        'email': u'organisation_admin@localhost',
+        'password': u'Password123!'
+    },
+    'Group Admin': {
+        'name': u'group_admin',
+        'email': u'group_admin@localhost',
+        'password': u'Password123!'
+    },
+    'Publisher': {
+        'name': u'editor',
+        'email': u'publisher@localhost',
+        'password': u'Password123!'
+    },
+    'Walker': {
+        'name': u'walker',
+        'email': u'walker@localhost',
+        'password': u'Password123!'
+    },
+    'Foodie': {
+        'name': u'foodie',
+        'email': u'foodie@localhost',
+        'password': u'Password123!'
+    },
     # This user will not be assigned to any organisations
     'CKANUser': {
         'name': u'ckan_user',
@@ -46,7 +71,7 @@ PERSONAS = {
         'name': u'test_org_member',
         'email': u'test_org_member@localhost',
         'password': u'Password123!'
-    }
+    },
 }
 
 
@@ -55,6 +80,8 @@ def before_all(context):
     context.screenshots_dir = os.path.join(ROOT_PATH, 'test/screenshots')
     # The path where file attachments can be found.
     context.attachment_dir = os.path.join(ROOT_PATH, 'test/fixtures')
+    # The path where emails can be found.
+    context.mail_path = os.path.join(ROOT_PATH, 'test/emails')
 
     # Set base url for all relative links.
     context.base_url = BASE_URL

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -1,0 +1,53 @@
+@users
+Feature: Group APIs
+
+    Scenario: Group membership is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I view the "silly-walks" group API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "group_admin"') and contains(string(), '"name": "walker"')]"
+
+    Scenario: Group membership is accessible to admins of the group
+        Given "Group Admin" as the persona
+        When I log in
+        And I view the "silly-walks" group API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "group_admin"') and contains(string(), '"name": "walker"')]"
+
+    Scenario: Group membership is not accessible to non-admins
+        Given "Walker" as the persona
+        When I log in
+        And I view the "silly-walks" group API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: Group membership is not accessible to other admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I view the "silly-walks" group API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: Group membership is not accessible anonymously
+        When I view the "silly-walks" group API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+
+    Scenario: Group overview is accessible to admins of the group
+        Given "Group Admin" as the persona
+        When I log in
+        And I view the "silly-walks" group API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "silly-walks"')]"
+
+    Scenario: Group overview is accessible to non-admins
+        Given "Walker" as the persona
+        When I log in
+        And I view the "silly-walks" group API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "silly-walks"')]"
+
+    Scenario: Group overview is accessible to other admins
+        Given "Foodie" as the persona
+        When I log in
+        And I view the "silly-walks" group API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "silly-walks"')]"
+
+    Scenario: Group overview is accessible anonymously
+        When I view the "silly-walks" group API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "silly-walks"')]"

--- a/test/features/organisations.feature
+++ b/test/features/organisations.feature
@@ -1,0 +1,53 @@
+@users
+Feature: Organization APIs
+
+    Scenario: Organisation membership is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "organisation_admin"') and contains(string(), '"name": "editor"')]"
+
+    Scenario: Organisation membership is accessible to admins of the organisation
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "organisation_admin"') and contains(string(), '"name": "editor"')]"
+
+    Scenario: Organisation membership is not accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: Organisation membership is not accessible to other admins
+        Given "Foodie" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: Organisation membership is not accessible anonymously
+        When I view the "department-of-health" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+
+    Scenario: Organisation overview is accessible to admins of the organisation
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "department-of-health"')]"
+
+    Scenario: Organisation overview is accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "department-of-health"')]"
+
+    Scenario: Organisation overview is accessible to other admins
+        Given "Foodie" as the persona
+        When I log in
+        And I view the "department-of-health" organisation API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "department-of-health"')]"
+
+    Scenario: Organisation overview is accessible anonymously
+        When I view the "department-of-health" organisation API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "department-of-health"')]"

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -1,0 +1,22 @@
+@resources
+Feature: Resource UI
+
+    Scenario Outline: Link resource should create a link to its URL
+        Given "SysAdmin" as the persona
+        When I create a resource with name "<name>" and URL "<url>"
+        And I press the element with xpath "//a[contains(@title, '<name>') and contains(string(), '<name>')]"
+        Then I should see "<url>"
+
+        Examples:
+        | name | url |
+        | Good link | http://www.qld.gov.au |
+        | Good IP address | http://1.2.3.4 |
+        | Domain starting with numbers | http://1.2.3.4.example.com |
+        | Domain ending with numbers | http://example.com.1.2.3.4 |
+        | Domain ending with private | http://example.com.private |
+
+    Scenario: Link resource with missing or invalid protocol should use HTTP
+        Given "SysAdmin" as the persona
+        When I create a resource with name "Non-HTTP link" and URL "git+https://github.com/ckan/ckan.git"
+        And I press the element with xpath "//a[contains(@title, 'Non-HTTP link') and contains(string(), 'Non-HTTP link')]"
+        And I should see "http://git+https://github.com/ckan/ckan.git"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -2,6 +2,7 @@ from behave import step
 from behaving.personas.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
+import random
 
 
 @step(u'I get the current URL')
@@ -42,11 +43,19 @@ def log_in_directly(context):
 
     assert context.persona
     context.execute_steps(u"""
-        When I fill in "login" with "$name"
-        And I fill in "password" with "$password"
-        And I press the element with xpath "//button[contains(string(), 'Login')]"
+        When I attempt to log in with password "$password"
         Then I should see an element with xpath "//a[@title='Log out']"
     """)
+
+
+@step(u'I attempt to log in with password "{password}"')
+def attempt_login(context, password):
+    assert context.persona
+    context.execute_steps(u"""
+        When I fill in "login" with "$name"
+        And I fill in "password" with "{}"
+        And I press the element with xpath "//button[contains(string(), 'Login')]"
+    """.format(password))
 
 
 @step(u'I should see a login link')
@@ -54,6 +63,27 @@ def login_link_visible(context):
     context.execute_steps(u"""
         Then I should see an element with xpath "//h1[contains(string(), 'Login')]"
     """)
+
+
+@step(u'I create a resource with name "{name}" and URL "{url}"')
+def add_resource(context, name, url):
+    context.execute_steps(u"""
+        When I log in
+        And I visit "/dataset/new_resource/warandpeace"
+        And I execute the script "document.getElementById('field-image-url').value='{url}'"
+        And I fill in "name" with "{name}"
+        And I fill in "description" with "description"
+        And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
+    """.format(name=name, url=url))
+
+
+@step(u'I fill in title with random text')
+def title_random_text(context):
+
+    assert context.persona
+    context.execute_steps(u"""
+        When I fill in "title" with "Test Title {0}"
+    """.format(random.randrange(1000)))
 
 
 @step(u'I go to dataset page')
@@ -81,7 +111,101 @@ def set_persona_var(context, key, value):
     context.persona[key] = value
 
 
-@step('I log in and go to admin config page')
+@step(u'I lock my account')
+def lock_account(context):
+    when_i_visit_url(context, "/user/login")
+    for x in range(11):
+        attempt_login(context, "incorrect password")
+
+
+@step(u'I request a password reset')
+def request_reset(context):
+    assert context.persona
+    context.execute_steps(u"""
+        When I visit "/user/reset"
+        And I fill in "user" with "$name"
+        And I press the element with xpath "//button[contains(string(), 'Request Reset')]"
+        And I go to dataset page
+    """)
+
+
+@step(u'I search the autocomplete API for user "{username}"')
+def go_to_user_autocomplete(context, username):
+    when_i_visit_url(context, '/api/2/util/user/autocomplete?q={}'.format(username))
+
+
+@step(u'I go to the user list API')
+def go_to_user_list(context):
+    when_i_visit_url(context, '/api/3/action/user_list')
+
+
+@step(u'I go to the "{user_id}" profile page')
+def go_to_user_profile(context, user_id):
+    when_i_visit_url(context, '/user/{}'.format(user_id))
+
+
+@step(u'I go to the dashboard')
+def go_to_dashboard(context):
+    when_i_visit_url(context, '/dashboard')
+
+
+@step(u'I go to the "{user_id}" user API')
+def go_to_user_show(context, user_id):
+    when_i_visit_url(context, '/api/3/action/user_show?id={}'.format(user_id))
+
+
+@step(u'I view the "{group_id}" group API "{including}" users')
+def go_to_group_including_users(context, group_id, including):
+    when_i_visit_url(context, r'/api/3/action/group_show?id={}&include_users={}'.format(group_id, including in ['with', 'including']))
+
+
+@step(u'I view the "{organisation_id}" organisation API "{including}" users')
+def go_to_organisation_including_users(context, organisation_id, including):
+    when_i_visit_url(context, r'/api/3/action/organization_show?id={}&include_users={}'.format(organisation_id, including in ['with', 'including']))
+
+
+@step(u'I create a dataset with title "{title}"')
+def create_dataset_titled(context, title):
+    context.execute_steps(u"""
+        When I visit "/dataset/new"
+        And I fill in "title" with "{title}"
+        And I fill in "notes" with "Description"
+        And I fill in "version" with "1.0"
+        And I fill in "author_email" with "test@me.com"
+        And I press "Add Data"
+        And I execute the script "document.getElementById('field-image-url').value='https://example.com'"
+        And I fill in "name" with "Test Resource"
+        And I select "HTML" from "format"
+        And I fill in "description" with "Test Resource Description"
+        And I press "Finish"
+    """.format(title=title))
+
+
+@step(u'I create a dataset with license {license} and resource file {file}')
+def create_dataset_json(context, license, file):
+    create_dataset(context, license, 'JSON', file)
+
+
+@step(u'I create a dataset with license {license} and {file_format} resource file {file}')
+def create_dataset(context, license, file_format, file):
+    assert context.persona
+    context.execute_steps(u"""
+        When I visit "/dataset/new"
+        And I fill in title with random text
+        And I fill in "notes" with "Description"
+        And I fill in "version" with "1.0"
+        And I fill in "author_email" with "test@me.com"
+        And I execute the script "document.getElementById('field-license_id').value={license}"
+        And I press "Add Data"
+        And I attach the file {file} to "upload"
+        And I fill in "name" with "Test Resource"
+        And I execute the script "document.getElementById('field-format').value={file_format}"
+        And I fill in "description" with "Test Resource Description"
+        And I press "Finish"
+    """.format(license=license, file=file, file_format=file_format))
+
+
+@step(u'I log in and go to admin config page')
 def log_in_go_to_admin_config(context):
     assert context.persona
     context.execute_steps(u"""
@@ -90,6 +214,6 @@ def log_in_go_to_admin_config(context):
     """)
 
 
-@step('I go to admin config page')
+@step(u'I go to admin config page')
 def go_to_admin_config(context):
     when_i_visit_url(context, '/ckan-admin/config')

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -1,5 +1,6 @@
 from behave import step
 from behaving.personas.steps import *  # noqa: F401, F403
+from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
 import random

--- a/test/features/user_creation.feature
+++ b/test/features/user_creation.feature
@@ -7,7 +7,7 @@ Feature: User creation
         Then I go to "/ckan-admin/config"
         Then I should see "Excluded display name words"
         Then I fill in "ckanext.data_qld.excluded_display_name_words" with "gov"
-        Then I press "save"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
 
 
     Scenario: SysAdmin create a new user to the site.
@@ -17,7 +17,7 @@ Feature: User creation
         Then I should see "Displayed name"
         Then I fill in "name" with "publisher_user"
         Then I fill in "fullname" with "gov user"
-        Then I press "save"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
         And I wait for 10 seconds
         Then I should not see "The username cannot contain the word 'publisher'. Please enter another username."
         Then I should not see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."
@@ -29,7 +29,7 @@ Feature: User creation
         Then I should see "Displayed name"
         Then I fill in "name" with "publisher_user"
         Then I fill in "fullname" with "gov user"
-        Then I press "save"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
         And I wait for 10 seconds
         Then I should see "The username cannot contain the word 'publisher'. Please enter another username."
         Then I should see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -1,0 +1,173 @@
+@users
+Feature: User APIs
+
+    Scenario: User autocomplete is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I search the autocomplete API for user "admin"
+        Then I should see an element with xpath "//*[contains(string(), '"name": "admin"')]"
+
+    Scenario: User autocomplete is accessible to organisation admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I search the autocomplete API for user "admin"
+        Then I should see an element with xpath "//*[contains(string(), '"name": "admin"')]"
+
+    Scenario: User autocomplete is accessible to group admins
+        Given "Group Admin" as the persona
+        When I log in
+        And I search the autocomplete API for user "admin"
+        Then I should see an element with xpath "//*[contains(string(), '"name": "admin"')]"
+
+    Scenario: User autocomplete is not accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I search the autocomplete API for user "admin"
+        Then I should see an element with xpath "//body//div[contains(string(), 'Internal server error')]"
+        And I should not see an element with xpath "//*[contains(string(), '"name": "admin"')]"
+
+    Scenario: User autocomplete is not accessible anonymously
+        When I search the autocomplete API for user "admin"
+        Then I should see an element with xpath "//body//div[contains(string(), 'Internal server error')]"
+        And I should not see an element with xpath "//*[contains(string(), '"name": "admin"')]"
+
+
+    Scenario: User list is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I go to the user list API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "admin"')]"
+
+    Scenario: User list is accessible to organisation admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I go to the user list API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "admin"')]"
+
+    Scenario: User list is accessible to group admins
+        Given "Group Admin" as the persona
+        When I log in
+        And I go to the user list API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "admin"')]"
+
+    Scenario: User list is not accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the user list API
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: User list is not accessible anonymously
+        When I go to the user list API
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'requires an authenticated user')]"
+
+
+    Scenario: User detail is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I go to the "admin" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "admin"')]"
+
+    Scenario: User detail is accessible to organisation admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I go to the "editor" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "editor"')]"
+
+    Scenario: User detail is accessible to group admins
+        Given "Group Admin" as the persona
+        When I log in
+        And I go to the "editor" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "editor"')]"
+
+    Scenario: User detail for self is accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the "editor" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true,') and contains(string(), '"name": "editor"')]"
+
+    Scenario: Non-self user detail is not accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the "admin" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'Authorization Error')]"
+
+    Scenario: User detail is not accessible anonymously
+        When I go to the "editor" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": false,') and contains(string(), 'requires an authenticated user')]"
+
+
+    Scenario: User profile page is accessible to sysadmins
+        Given "SysAdmin" as the persona
+        When I log in
+        And I go to the "admin" profile page
+        Then I should see an element with xpath "//h1[string() = 'Administrator']"
+
+    Scenario: User profile page is accessible to organisation admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I go to the "editor" profile page
+        Then I should see an element with xpath "//h1[string() = 'Publisher']"
+
+    Scenario: User profile page is accessible to group admins
+        Given "Organisation Admin" as the persona
+        When I log in
+        And I go to the "editor" profile page
+        Then I should see an element with xpath "//h1[string() = 'Publisher']"
+
+    Scenario: User profile page for self is accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the "editor" profile page
+        Then I should see an element with xpath "//h1[string() = 'Publisher']"
+
+    Scenario: Non-self user profile page is not accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the "admin" profile page
+        Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
+
+    Scenario: User profile page is not accessible anonymously
+        When I go to the "editor" profile page
+        Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
+
+
+    Scenario: Dashboard page is accessible to non-admins
+        Given "Publisher" as the persona
+        When I log in
+        And I go to the dashboard
+        Then I should see an element with xpath "//h2[contains(string(), 'News feed')]"
+
+
+    Scenario: As a registered user, when I have locked my account with too many failed logins, I can reset my password to unlock it
+        Given "Walker" as the persona
+        When I lock my account
+        And I go to "/user/login"
+        And I attempt to log in with password "$password"
+        Then I should see "Login failed"
+        When I request a password reset
+        Then I should see an element with xpath "//div[contains(string(), 'A reset link has been emailed to you')]"
+        When I wait for 3 seconds
+        Then I should receive an email at "$email" containing "You have requested your password"
+        When I parse the email I received at "$email" and set "{domain}/user/reset/{path}Have"
+        And I go to "/user/reset/$path"
+        Then the browser's URL should contain "/user/reset/"
+        And the browser's URL should contain "key="
+        When I fill in "password1" with "$password"
+        And I fill in "password2" with "$password"
+        And I press the element with xpath "//button[@class='btn btn-primary']"
+        Then I log in
+
+
+    Scenario: Register user password must be 10 characters or longer and contain number, lowercase, capital, and symbol
+        When I go to register page
+        And I fill in "name" with "name"
+        And I fill in "fullname" with "fullname"
+        And I fill in "email" with "email@test.com"
+        And I fill in "password1" with "pass"
+        And I fill in "password2" with "pass"
+        And I press "Create Account"
+        Then I should see "Password: Your password must be 10 characters or longer"
+        Then I fill in "password1" with "password1234"
+        And I fill in "password2" with "password1234"
+        And I press "Create Account"
+        Then I should see "Password: Must contain at least one number, lowercase letter, capital letter, and symbol"


### PR DESCRIPTION
- Use URL to control template contents, instead of detecting controller
- Detect either Flask or Pylons request for custom error messages
- Restore organisation snippet so we don't display a "No description" message
- Add CKAN 2.9 testing to CI
- Copy more tests from ckanext-qgov since we want to ensure the theme doesn't interfere with it