### PR TITLE
[QOL-8779] expose /header.html under Flask to support Squiz homepage

### DIFF
--- a/ckanext/publications_qld_theme/blueprints.py
+++ b/ckanext/publications_qld_theme/blueprints.py
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+from flask import Blueprint
+
+from ckantoolkit import render
+
+
+def header_snippet():
+    return render('header.html')
+
+
+blueprint = Blueprint(
+    u'publications_qld',
+    __name__
+)
+
+blueprint.add_url_rule(u'/header.html', view_func=header_snippet)

--- a/ckanext/publications_qld_theme/plugin.py
+++ b/ckanext/publications_qld_theme/plugin.py
@@ -1,10 +1,13 @@
-import ckan.plugins as plugins
-import ckan.plugins.toolkit as toolkit
-import datetime
+# encoding: utf-8
 
-from ckan.common import c, config, request
-import ckan.model as model
+import datetime
 import re
+
+from ckan import model, plugins
+from ckan.plugins import toolkit
+from ckan.common import c, config, request
+
+import blueprints
 
 
 def get_gtm_code():
@@ -140,6 +143,8 @@ def unreplied_comments_x_days(thread_url):
 class PublicationsQldThemePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.ITemplateHelpers)
+    if toolkit.check_ckan_version('2.9'):
+        plugins.implements(plugins.IBlueprint)
 
     # IConfigurer
 
@@ -166,3 +171,8 @@ class PublicationsQldThemePlugin(plugins.SingletonPlugin):
             'unreplied_comments_x_days': unreplied_comments_x_days,
             'is_reporting_enabled': is_reporting_enabled
         }
+
+    # IBlueprint
+
+    def get_blueprint(self):
+        return blueprints.blueprint

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -100,3 +100,9 @@ Feature: Theme customisations
         When I go to "/nonexistent"
         Then I should see an element with xpath "//div[contains(string(), 'was not found') or contains(string(), 'could not be found')]"
         And I should not see "Sorry, the page you were looking for could not be found."
+
+    Scenario: When I go to the header URL, I can see the list of necessary assets
+        When I go to "/header.html"
+        Then I should see an element with xpath "//a[@href='/user/login' and contains(string(), 'Log in')]"
+        And I should see an element with xpath "//a[@href='/user/register' and contains(string(), 'Register')]"
+        And I should not see "not found"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -3,7 +3,7 @@ from behaving.personas.steps import *  # noqa: F401, F403
 from behaving.mail.steps import *  # noqa: F401, F403
 from behaving.web.steps import *  # noqa: F401, F403
 from behaving.web.steps.url import when_i_visit_url
-import random
+import uuid
 
 
 @step(u'I get the current URL')
@@ -85,7 +85,7 @@ def title_random_text(context):
     assert context.persona
     context.execute_steps(u"""
         When I fill in "title" with "Test Title {0}"
-    """.format(random.randrange(100000)))
+    """.format(uuid.uuid4()))
 
 
 @step(u'I go to dataset page')

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -74,6 +74,7 @@ def add_resource(context, name, url):
         And I execute the script "document.getElementById('field-image-url').value='{url}'"
         And I fill in "name" with "{name}"
         And I fill in "description" with "description"
+        And I execute the script "size_field = document.getElementById('field-size'); if (size_field) size_field.value = '1024';"
         And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
     """.format(name=name, url=url))
 
@@ -84,7 +85,7 @@ def title_random_text(context):
     assert context.persona
     context.execute_steps(u"""
         When I fill in "title" with "Test Title {0}"
-    """.format(random.randrange(1000)))
+    """.format(random.randrange(100000)))
 
 
 @step(u'I go to dataset page')
@@ -178,7 +179,7 @@ def create_dataset_titled(context, title):
         And I fill in "name" with "Test Resource"
         And I select "HTML" from "format"
         And I fill in "description" with "Test Resource Description"
-        And I press "Finish"
+        And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
     """.format(title=title))
 
 
@@ -202,7 +203,7 @@ def create_dataset(context, license, file_format, file):
         And I fill in "name" with "Test Resource"
         And I execute the script "document.getElementById('field-format').value={file_format}"
         And I fill in "description" with "Test Resource Description"
-        And I press "Finish"
+        And I press the element with xpath "//form[contains(@class, 'resource-form')]//button[contains(@class, 'btn-primary')]"
     """.format(license=license, file=file, file_format=file_format))
 
 


### PR DESCRIPTION
Pylons already exposes this, and Squiz relies on it to assemble the page, but Flask will not unless we add a specific route for it.