### PR TITLE
[DC-30092] retrieve the latest revision date to populate the resource modified date

### DIFF
--- a/ckanext/publications_qld_theme/templates/package/resource_read.html
+++ b/ckanext/publications_qld_theme/templates/package/resource_read.html
@@ -23,59 +23,59 @@
 {% block primary_content %}
 {% block resource %}
 <section class="module module-resource">
-	{% block resource_inner %}
-	<div class="module-content">
-		<div class="actions">
-			{% block resource_actions %}
-			<ul>
-				{% block resource_actions_inner %}
-				{% if h.check_access('package_update', {'id':pkg.id }) %}
-					<li>
-					{% if h.ckan_version() > '2.9' %}
-						{% link_for _('Manage'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}
-					{% else %}
-						{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}
-					{% endif %}
-					</li>
-				{% endif %}
-				{% if res.url and h.is_url(res.url) %}
-				<li>
-					<div class="btn-group">
-						<a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }} resource-btn" href="{{ res.url }}">
-							{% if res.resource_type in ('listing', 'service') %}
-							<i class="fa fa-eye"></i> {{ _('View') }}
-							{% elif  res.resource_type == 'api' %}
-							<i class="fa fa-key"></i> {{ _('API Endpoint') }}
-							{% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
-							<i class="fa fa-external-link"></i> {{ _('Go to resource') }}
-							{% else %}
-							<i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
-								{% if res.actual_size or res.size %}({{ res.actual_size or  h.format_resource_filesize(res.size) }}){% endif %}
-								{% if res.format %}({{ res.format }}){% endif %}
-							{% endif %}
-						</a>
-						{% block download_resource_button %}
-							{{ super() }}
-						{% endblock %}
-					</div>
-				</li>
-				{% endif %}
-				{% if res.datastore_active %}
-				<li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
-			  	{% endif %}
-				{% endblock %}
-			</ul>
-			{% endblock %}
-		</div>
-		{% block resource_content %}
-		{{ super() }}
-		{% endblock %}
-		{% block data_preview %}
-		{% if res.datastore_active %}
-			{{ super() }}
-		{% endif %}
-		{% endblock %}
-		{% endblock %}
+    {% block resource_inner %}
+    <div class="module-content">
+        <div class="actions">
+            {% block resource_actions %}
+            <ul>
+                {% block resource_actions_inner %}
+                {% if h.check_access('package_update', {'id':pkg.id }) %}
+                    <li>
+                    {% if h.ckan_version() > '2.9' %}
+                        {% link_for _('Manage'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}
+                    {% else %}
+                        {% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}
+                    {% endif %}
+                    </li>
+                {% endif %}
+                {% if res.url and h.is_url(res.url) %}
+                <li>
+                    <div class="btn-group">
+                        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }} resource-btn" href="{{ res.url }}">
+                            {% if res.resource_type in ('listing', 'service') %}
+                            <i class="fa fa-eye"></i> {{ _('View') }}
+                            {% elif  res.resource_type == 'api' %}
+                            <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+                            {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
+                            <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+                            {% else %}
+                            <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+                                {% if res.actual_size or res.size %}({{ res.actual_size or  h.format_resource_filesize(res.size) }}){% endif %}
+                                {% if res.format %}({{ res.format }}){% endif %}
+                            {% endif %}
+                        </a>
+                        {% block download_resource_button %}
+                            {{ super() }}
+                        {% endblock %}
+                    </div>
+                </li>
+                {% endif %}
+                {% if res.datastore_active %}
+                <li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
+                {% endif %}
+                {% endblock %}
+            </ul>
+            {% endblock %}
+        </div>
+        {% block resource_content %}
+        {{ super() }}
+        {% endblock %}
+        {% block data_preview %}
+        {% if res.datastore_active %}
+            {{ super() }}
+        {% endif %}
+        {% endblock %}
+        {% endblock %}
 </section>
 {% endblock %}
 {% block resource_additional_information_inner %}
@@ -104,15 +104,16 @@
     </div>
   {% endblock %}
   {% endif %}
+  {% do h.populate_revision(res) %}
   {{ super() }}
 {% endblock %}
 {% endblock %}
 
 {% block resource_read_title %}
-	<h1 class="page-heading">{{ h.resource_display_name(res)}}
-	{% if res.schema %}
-		{{ h.get_validation_badge(res)|safe }}
-		{% resource 'ckanext-validation/main' %}
-	{% endif %}
-	</h1>
+    <h1 class="page-heading">{{ h.resource_display_name(res)}}
+    {% if res.schema %}
+        {{ h.get_validation_badge(res)|safe }}
+        {% resource 'ckanext-validation/main' %}
+    {% endif %}
+    </h1>
 {% endblock %}


### PR DESCRIPTION
This will become irrelevant upon updating to CKAN 2.9, but is needed for 2.8