### PR TITLE
[QOL-8618] add DCTERMS metadata to more pages

### DIFF
--- a/ckanext/publications_qld_theme/templates/base.html
+++ b/ckanext/publications_qld_theme/templates/base.html
@@ -1,7 +1,14 @@
 {% ckan_extends %}
 
-  {% block custom_styles %}
-    <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" />
-    <link href="{{ h.set_external_resources() }}/__data/assets/git_bridge/0019/100846/open-data/dist/qld.css?h=288c0ce" rel="stylesheet" />
-    {% resource 'publications_qld_theme/publications_qld.css' %}
-  {% endblock %}
+{% block meta %}
+{{ super() }}
+<meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland" />
+<meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland" />
+<meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text" />
+{% endblock %}
+
+{% block custom_styles %}
+  <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" />
+  <link href="{{ h.set_external_resources() }}/__data/assets/git_bridge/0019/100846/open-data/dist/qld.css?h=288c0ce" rel="stylesheet" />
+  {% resource 'publications_qld_theme/publications_qld.css' %}
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/group/index.html
+++ b/ckanext/publications_qld_theme/templates/group/index.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block meta %}
+{{ super() }}
+<meta name="DCTERMS.title" content="{{ _('Groups') }}" />
+
+<meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland;" />
+<meta name="DCTERMS.description" content="List of all groups" />
+
+<meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/group/read_base.html
+++ b/ckanext/publications_qld_theme/templates/group/read_base.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block meta %}
+{% set group_dict = group_dict or c.group_dict %}
+{{ super() }}
+<meta name="DCTERMS.title" content="{{ group_dict.display_name }}" />
+
+<meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou={{ group_dict.display_name }}" />
+<meta name="DCTERMS.created" content="{{ h.reformat_date_string(group_dict['created']) }}" />
+<meta name="DCTERMS.description" content="{{ group_dict.get('description') or group_dict.display_name | truncate(500) }}" />
+<meta name="DCTERMS.identifier" content="{{ group_dict['id'] }}" />
+
+<meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="guidelines" />
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/organization/index.html
+++ b/ckanext/publications_qld_theme/templates/organization/index.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block meta %}
+{{ super() }}
+<meta name="DCTERMS.title" content="{{ _('Organizations') }}" />
+
+<meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland;" />
+<meta name="DCTERMS.description" content="List of all organisations" />
+
+<meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/organization/read_base.html
+++ b/ckanext/publications_qld_theme/templates/organization/read_base.html
@@ -1,18 +1,14 @@
 {% ckan_extends %}
 
-
 {% block meta %}
 {% set group_dict = group_dict or c.group_dict %}
 {{ super() }}
 <meta name="DCTERMS.title" content="{{ group_dict.display_name }}" />
 
-<meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland" />
 <meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou={{ group_dict.display_name }}" />
 <meta name="DCTERMS.created" content="{{ h.reformat_date_string(group_dict['created']) }}" />
 <meta name="DCTERMS.description" content="{{ group_dict.get('description') or group_dict.display_name | truncate(500) }}" />
 <meta name="DCTERMS.identifier" content="{{ group_dict['id'] }}" />
-<meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland" />
 
-<meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text" />
 <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="guidelines" />
 {% endblock %}

--- a/ckanext/publications_qld_theme/templates/package/read.html
+++ b/ckanext/publications_qld_theme/templates/package/read.html
@@ -4,7 +4,6 @@
 {{ super() }}
 <meta name="DCTERMS.title" content="{{ pkg['title'] or pkg['name'] }}" />
 
-<meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland" />
 {% if pkg['organization'] and pkg['organization']['title'] %}
   <meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou={{ pkg['organization']['title'] }}" />
 {% endif %}
@@ -14,8 +13,6 @@
 {% endif %}
 <meta name="DCTERMS.description" content="{{ (pkg['notes'] or pkg['title'] or pkg['name']) | truncate(500) }}" />
 <meta name="DCTERMS.identifier" content="{{ pkg['id'] }}" />
-<meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland" />
 
-<meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text" />
 <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
 {% endblock %}

--- a/ckanext/publications_qld_theme/templates/package/resource_read.html
+++ b/ckanext/publications_qld_theme/templates/package/resource_read.html
@@ -6,7 +6,6 @@
 {{ super() }}
 <meta name="DCTERMS.title" content="{{ h.resource_display_name(res) }}" />
 
-<meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland" />
 {% if pkg['organization'] and pkg['organization']['title'] %}
   <meta name="DCTERMS.creator" content="c=AU; o=The State of Queensland; ou={{ pkg['organization']['title'] }}" scheme="AGLSTERMS.GOLD" />
 {% endif %}
@@ -15,9 +14,7 @@
 <meta name="DCTERMS.modified" content="{{ h.reformat_date_string(res.metadata_modified or res.last_modified or res.created) or _('unknown') }}" />
 <meta name="DCTERMS.description" content="{{ (res.description or res.name) | truncate(500) }}" />
 <meta name="DCTERMS.identifier" content="{{ res.id }}" />
-<meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland" />
 
-<meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text" />
 <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="dataset" />
 {% endblock %}
 

--- a/ckanext/publications_qld_theme/templates/package/search.html
+++ b/ckanext/publications_qld_theme/templates/package/search.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block meta %}
+{{ super() }}
+<meta name="DCTERMS.title" content="{{ _('Datasets') }}" />
+
+<meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland;" />
+<meta name="DCTERMS.description" content="List of all datasets" />
+
+<meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
+{% endblock %}

--- a/test/features/google_analytics.feature
+++ b/test/features/google_analytics.feature
@@ -17,9 +17,9 @@ Feature: GoogleAnalytics
 
         When I click the link with text that contains "Dave's books"
         And I click the link with text that contains "About"
-        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Dave's books']"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and contains(@content, 'Dave')]"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Dave's books' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and contains(@content, 'c=AU; o=The State of Queensland; ou=Dave') and @scheme='AGLSTERMS.GOLD']"
         And I should see an element with xpath "//meta[@name='DCTERMS.created' and @content != '' and @content != 'None']"
         And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='These are books that David likes.']"
         And I should see an element with xpath "//meta[@name='DCTERMS.identifier' and @content != '' and @content != 'None']"

--- a/test/features/google_analytics.feature
+++ b/test/features/google_analytics.feature
@@ -5,9 +5,39 @@ Feature: GoogleAnalytics
         When I go to homepage
         Then I should see an element with xpath "//script[@src='//www.googletagmanager.com/gtm.js?id=False']"
 
+    Scenario: When viewing the HTML source code of a group, the appropriate metadata is visible
+        When I go to group page
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Groups']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='List of all groups']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
+        And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
+
+        When I click the link with text that contains "Dave's books"
+        And I click the link with text that contains "About"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Dave's books']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Dave's books' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.created' and @content != '' and @content != 'None']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='These are books that David likes.']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.identifier' and @content != '' and @content != 'None']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
+        And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='guidelines']"
+
     Scenario: When viewing the HTML source code of an organisation, the appropriate metadata is visible
         When I go to organisation page
-        And I click the link with text that contains "Department of Health"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Organisations']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='List of all organisations']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
+        And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
+
+        When I click the link with text that contains "Department of Health"
         And I click the link with text that contains "About"
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Department of Health']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
@@ -19,9 +49,17 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='guidelines']"
 
-    Scenario: When viewing the HTML source code of a dataset, the appropriate metadata is visible
+    Scenario: When viewing the HTML source code of a resource, the appropriate metadata is visible
         When I go to Dataset page
-        And I click the link with text that contains "A Novel By Tolstoy"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Datasets']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='List of all datasets']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
+        And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
+
+        When I click the link with text that contains "A Novel By Tolstoy"
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='A Novel By Tolstoy']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Test Organisation' and @scheme='AGLSTERMS.GOLD']"
@@ -33,10 +71,7 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
-    Scenario: When viewing the HTML source code of a resource, the appropriate metadata is visible
-        When I go to Dataset page
-        And I click the link with text that contains "A Novel By Tolstoy"
-        And I click the link with text that contains "Full text"
+        When I click the link with text that contains "Full text"
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Full text']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Test Organisation' and @scheme='AGLSTERMS.GOLD']"

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -5,3 +5,6 @@ Feature: Homepage
     Scenario: Smoke test to ensure Homepage is accessible
         When I go to homepage
         Then I take a screenshot
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"

--- a/test/features/login.feature
+++ b/test/features/login.feature
@@ -5,3 +5,6 @@ Feature: Login
         Given "SysAdmin" as the persona
         When I log in
         Then I take a screenshot
+        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -103,6 +103,11 @@ def edit_dataset(context, name):
     when_i_visit_url(context, '/dataset/edit/{}'.format(name))
 
 
+@step(u'I go to group page')
+def go_to_group_page(context):
+    when_i_visit_url(context, '/group')
+
+
 @step(u'I go to organisation page')
 def go_to_organisation_page(context):
     when_i_visit_url(context, '/organization')


### PR DESCRIPTION
- add to organisation list, group list, dataset search
- move fixed metadata into global base so it applies to all pages