### PR TITLE
[QOL-8871] update 'Publish in the Gazettes' homepage link

### DIFF
--- a/ckanext/publications_qld_theme/templates/home/index.html
+++ b/ckanext/publications_qld_theme/templates/home/index.html
@@ -61,9 +61,7 @@
                     <div id="home-gazettes" class="tiles__title">{{ _('Queensland Government Gazettes') }}</div>
                     <div class="tiles__content">
                         <ul>
-                          <li><a href="https://www.qld.gov.au/gov/publish-gazette?tab=get-started ">Publish in the Gazettes</a></li>
-                          <li><a href="https://www.qld.gov.au/gov/how-much-does-it-cost-publish-gazette-notice">Find out your costs</a></li>
-                          <li><a href="https://www.qld.gov.au/gov/when-are-deadlines-providing-content-publication-queensland-government-gazette ">Publishing deadlines</a></li>
+                          <li><a href="https://www.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/queensland-government-gazette/publish-in-the-gazette">Publish in the Gazettes</a></li>
                           <li><a href="/group/gazettes-2022">Gazettes 2022</a></li>
                           <li><a href="/group/gazettes-2021">Gazettes 2021</a></li>
                           <li><a href="/group/gazettes-2020">Gazettes 2020</a></li>

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -4,7 +4,7 @@ Feature: Homepage
     @homepage
     Scenario: Smoke test to ensure Homepage is accessible
         When I go to homepage
-        Then I take a screenshot
+        Then I should see an element with xpath "//a[@href='https://www.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/queensland-government-gazette/publish-in-the-gazette' and string()='Publish in the Gazettes']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"


### PR DESCRIPTION
- Use just one link instead of three, and go straight to the destination instead of redirecting via www.qld.gov.au