### PR TITLE
[QOL-8989] add our custom robots.txt file

### DIFF
--- a/ckanext/publications_qld_theme/blueprints.py
+++ b/ckanext/publications_qld_theme/blueprints.py
@@ -5,13 +5,10 @@ from flask import Blueprint
 from ckantoolkit import render
 
 
-def header_snippet():
-    return render('header.html')
-
-
 blueprint = Blueprint(
     u'publications_qld',
     __name__
 )
 
-blueprint.add_url_rule(u'/header.html', view_func=header_snippet)
+blueprint.add_url_rule(u'/header.html', 'header', view_func=lambda: render('header.html'))
+blueprint.add_url_rule(u'/robots.txt', 'robots', view_func=lambda: render('robots.txt'))

--- a/ckanext/publications_qld_theme/templates/robots.txt
+++ b/ckanext/publications_qld_theme/templates/robots.txt
@@ -1,5 +1,3 @@
-{% ckan_extends %}
-
 {% block all_user_agents %}
 {% if h.is_prod() %}
 {% raw %}

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -106,3 +106,10 @@ Feature: Theme customisations
         Then I should see an element with xpath "//a[@href='/user/login' and contains(string(), 'Log in')]"
         And I should see an element with xpath "//a[@href='/user/register' and contains(string(), 'Register')]"
         And I should not see "not found"
+
+    @unauthenticated
+    Scenario: When I go to the robots file, I can see a custom disallow block
+        Given "Unauthenticated" as the persona
+        When I go to "/robots.txt"
+        Then I should see "Disallow: /"
+        And I should not see "Allow:"


### PR DESCRIPTION
- CKAN 2.9 reverted to serving it from the 'public' directory, but we want Jinja syntax,
so instead we add a Flask blueprint rule to render it