### PR TITLE
QOLSVC-2447 preserve resource names in links

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -19,6 +19,7 @@ commands:
   build-network:
     usage: Ensure that the amazeeio network exists.
     cmd: |
+      ahoy title "Creating amazeeio Docker network"
       docker network prune -f > /dev/null
       docker network inspect amazeeio-network > /dev/null || docker network create amazeeio-network
 
@@ -34,13 +35,14 @@ commands:
   up:
     usage: Build and start Docker containers.
     cmd: |
+      ahoy title "Building and starting Docker containers"
       docker-compose up -d "$@"
+      echo "Initialising database schema"
       ahoy cli '$APP_DIR/bin/init.sh'
-      sleep 10
-      docker-compose logs
+      echo "Waiting for containers to start listening..."
       ahoy cli "dockerize -wait tcp://ckan:5000 -timeout 1m"
-      if docker-compose logs | grep -q "\[Error\]"; then docker-compose logs; exit 1; fi
-      if docker-compose logs | grep -q "Exception"; then docker-compose logs; exit 1; fi
+      if docker-compose logs | grep -q "\[Error\]"; then exit 1; fi
+      if docker-compose logs | grep -q "Exception"; then exit 1; fi
       docker ps -a --filter name=^/${COMPOSE_PROJECT_NAME}_
       export DOCTOR_CHECK_CLI=0
 
@@ -66,7 +68,7 @@ commands:
 
   pull:
     usage: Pull latest docker images.
-    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep amazeeio/ | grep -v none | xargs -n1 docker pull | cat; fi
+    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep ckan/ckan- | grep -v none | xargs -n1 docker pull | cat; fi
 
   cli:
     usage: Start a shell inside CLI container or run a command.
@@ -78,11 +80,14 @@ commands:
 
   install-site:
     usage: Install test site data.
-    cmd: ahoy cli '$APP_DIR/bin/init.sh && $APP_DIR/bin/create-test-data.sh'
+    cmd: |
+      ahoy title "Installing a fresh site"
+      ahoy cli '$APP_DIR/bin/init.sh && $APP_DIR/bin/create-test-data.sh'
 
   clean:
     usage: Remove containers and all build files.
     cmd: |
+      ahoy title "Cleaning up old builds"
       ahoy down
       # Remove other directories.
       # @todo: Add destinations below.
@@ -104,6 +109,7 @@ commands:
   lint:
     usage: Lint code.
     cmd: |
+      ahoy title 'Check for lint'
       ahoy cli "flake8 ${@:-ckanext}" || \
       [ "${ALLOW_LINT_FAIL:-0}" -eq 1 ]
 
@@ -112,22 +118,31 @@ commands:
     cmd: |
       docker cp . $(docker-compose ps -q ckan):/srv/app/
       docker cp bin/ckan_cli $(docker-compose ps -q ckan):/usr/bin/
-      ahoy cli 'chmod -v u+x /usr/bin/ckan_cli $APP_DIR/bin/*; cp -v .docker/test.ini $CKAN_INI'
+      ahoy cli 'chmod -v u+x /usr/bin/ckan_cli $APP_DIR/bin/*; cp -v .docker/test.ini $CKAN_INI; $APP_DIR/bin/process-config.sh'
 
   test-unit:
     usage: Run unit tests.
     cmd: |
+      ahoy title 'Run unit tests'
       ahoy cli 'pytest --ckan-ini=${CKAN_INI} $APP_DIR/ckanext' || \
       [ "${ALLOW_UNIT_FAIL:-0}" -eq 1 ]
 
   test-bdd:
     usage: Run BDD tests.
     cmd: |
+      ahoy title 'Run scenario tests'
+      ahoy cli "rm -f test/screenshots/*"
       ahoy start-mailmock &
-      sleep 5 &&
-      ahoy cli "behave -k ${*:-test/features} --tags=smoke" && \
-      ahoy cli "behave -k ${*:-test/features}" || \
-      [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      sleep 5
+      if [ "$BEHAVE_TAG" = "" ]; then
+        (ahoy cli "behave -k ${*:-test/features} --tags=smoke" \
+         && ahoy cli "behave -k ${*:-test/features}" \
+        ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      else
+        # run tests with the specified tag
+        ahoy cli "behave -k ${*:-test/features} --tags=$BEHAVE_TAG" \
+          || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+      fi
       ahoy stop-mailmock
 
   start-mailmock:

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -92,11 +92,12 @@ ckan.redis.url = redis://redis:6379
 
 ## Plugins Settings
 
-# Note: Add ``datastore`` to enable the CKAN DataStore
-#       Add ``datapusher`` to enable DataPusher
-#       Add ``resource_proxy`` to enable resource proxying and get around the
-#       same origin policy
-ckan.plugins = stats text_view image_view recline_view publications_qld_theme qgovext csrf_filter resource_type_validation ssm_config
+ckan.plugins =
+    publications_qld_theme
+    qgovext
+    csrf_filter
+    resource_type_validation
+    ssm_config
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.flake8
+++ b/.flake8
@@ -16,4 +16,5 @@ max-line-length = 127
 
 # List ignore rules one per line.
 ignore =
+    E501
     W503

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,10 @@ on:
       - master
 
 jobs:
+  # Quick check so we don't waste minutes if there's a Flake8 error
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -65,7 +66,7 @@ jobs:
 
       - name: Upload screenshots
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: CKAN ${{ matrix.ckan-version }} screenshots
           path: /tmp/artifacts/behave/screenshots

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -20,10 +20,11 @@ CKAN_GIT_VERSION=$CKAN_VERSION
 CKAN_GIT_ORG=qld-gov-au
 
 if [ "$CKAN_VERSION" = "2.10" ]; then
+    CKAN_GIT_VERSION=ckan-2.10.1-qgov.1
     PYTHON_VERSION=py3
     PYTHON="${PYTHON}3"
 else
-    CKAN_GIT_VERSION=ckan-2.9.5-qgov.9
+    CKAN_GIT_VERSION=ckan-2.9.9-qgov.2
     if [ "$CKAN_VERSION" = "2.9-py2" ]; then
         PYTHON_VERSION=py2
     else
@@ -39,4 +40,4 @@ sed "s|{CKAN_VERSION}|$CKAN_VERSION|g" .docker/Dockerfile-template.ckan \
     | sed "s|{PYTHON}|$PYTHON|g" \
     > .docker/Dockerfile.ckan
 
-ahoy build || (ahoy logs; exit 1)
+ahoy build

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -20,7 +20,7 @@ CKAN_GIT_VERSION=$CKAN_VERSION
 CKAN_GIT_ORG=qld-gov-au
 
 if [ "$CKAN_VERSION" = "2.10" ]; then
-    CKAN_GIT_VERSION=ckan-2.10.1-qgov.2
+    CKAN_GIT_VERSION=ckan-2.10.1-qgov.3
     PYTHON_VERSION=py3
     PYTHON="${PYTHON}3"
 else

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -20,11 +20,11 @@ CKAN_GIT_VERSION=$CKAN_VERSION
 CKAN_GIT_ORG=qld-gov-au
 
 if [ "$CKAN_VERSION" = "2.10" ]; then
-    CKAN_GIT_VERSION=ckan-2.10.1-qgov.1
+    CKAN_GIT_VERSION=ckan-2.10.1-qgov.2
     PYTHON_VERSION=py3
     PYTHON="${PYTHON}3"
 else
-    CKAN_GIT_VERSION=ckan-2.9.9-qgov.2
+    CKAN_GIT_VERSION=ckan-2.9.9-qgov.3
     if [ "$CKAN_VERSION" = "2.9-py2" ]; then
         PYTHON_VERSION=py2
     else

--- a/bin/ckan_cli
+++ b/bin/ckan_cli
@@ -59,14 +59,14 @@ fi
 if [ "$COMMAND" = "ckan" ]; then
     # adjust args to match ckan expectations
     COMMAND=$(echo "$1" | sed -e 's/create-test-data/seed/')
-    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
+    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND $1..." >&2
     exec $ENV_DIR/ckan -c ${CKAN_INI} $COMMAND "$@" $CLICK_ARGS
 elif [ "$COMMAND" = "paster" ]; then
     # adjust args to match paster expectations
     COMMAND=$1
-    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
+    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND $1..." >&2
     if [ "$1" = "show" ]; then shift; fi
     exec $ENV_DIR/paster --plugin=$PASTER_PLUGIN $COMMAND "$@" -c ${CKAN_INI}
 else

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -46,7 +46,8 @@ echo "Creating ${TEST_ORG_TITLE} organisation:"
 
 TEST_ORG=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "'"${TEST_ORG_NAME}"'", "title": "'"${TEST_ORG_TITLE}"'"}' \
+    --data '{"name": "'"${TEST_ORG_NAME}"'", "title": "'"${TEST_ORG_TITLE}"'",
+        "description": "Organisation for testing issues"}' \
     ${CKAN_ACTION_URL}/organization_create
 )
 
@@ -137,7 +138,7 @@ echo ${foodie_update}
 echo "Creating non-organisation group:"
 group_create=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=silly-walks" \
+    --data '{"name": "silly-walks", "title": "Silly walks", "description": "The Ministry of Silly Walks"}' \
     ${CKAN_ACTION_URL}/group_create
 )
 echo ${group_create}
@@ -145,7 +146,7 @@ echo ${group_create}
 echo "Updating group_admin to have admin privileges in the silly-walks group:"
 group_admin_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=silly-walks&username=group_admin&role=admin" \
+    --data '{"id": "silly-walks", "username": "group_admin", "role": "admin"}' \
     ${CKAN_ACTION_URL}/group_member_create
 )
 echo ${group_admin_update}
@@ -153,7 +154,7 @@ echo ${group_admin_update}
 echo "Updating walker to have editor privileges in the silly-walks group:"
 walker_update=$( \
     curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=silly-walks&username=walker&role=editor" \
+    --data '{"id": "silly-walks", "username": "walker", "role": "editor"}' \
     ${CKAN_ACTION_URL}/group_member_create
 )
 echo ${walker_update}

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -2,8 +2,7 @@
 ##
 # Create some example content for extension BDD tests.
 #
-set -e
-set -x
+set -ex
 
 CKAN_ACTION_URL=${CKAN_SITE_URL}api/action
 CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
@@ -28,6 +27,19 @@ if [ "$API_KEY" = "None" ]; then
     echo "No API Key found on ${CKAN_USER_NAME}, generating API Token..."
     API_KEY=$(ckan_cli user token add "${CKAN_USER_NAME}" test_setup |tail -1 | tr -d '[:space:]')
 fi
+
+##
+# BEGIN: Add sysadmin config values.
+#
+echo "Adding sysadmin config:"
+
+curl -LsH "Authorization: ${API_KEY}" \
+    --data '{"ckanext.data_qld.excluded_display_name_words": "gov"}' \
+    ${CKAN_ACTION_URL}/config_option_update
+
+##
+# END.
+#
 
 ##
 # BEGIN: Create a test organisation with test users for admin, editor and member
@@ -70,12 +82,6 @@ curl -LsH "Authorization: ${API_KEY}" \
 # END.
 #
 
-add_user_if_needed organisation_admin "Organisation Admin" organisation_admin@localhost
-add_user_if_needed editor "Publisher" publisher@localhost
-add_user_if_needed foodie "Foodie" foodie@localhost
-add_user_if_needed group_admin "Group Admin" group_admin@localhost
-add_user_if_needed walker "Walker" walker@localhost
-
 # Create private test dataset with our standard fields
 curl -LsH "Authorization: ${API_KEY}" \
     --data '{"name": "test-dataset", "owner_org": "'"${TEST_ORG_ID}"'", "private": true,
@@ -95,14 +101,6 @@ curl -LsH "Authorization: ${API_KEY}" \
 
 echo ${package_owner_org_update}
 
-echo "Creating department-of-health organisation:"
-organisation_create=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=department-of-health&title=Department%20of%20Health" \
-    ${CKAN_ACTION_URL}/organization_create
-)
-echo ${organisation_create}
-
 echo "Creating food-standards-agency organisation:"
 organisation_create=$( \
     curl -LsH "Authorization: ${API_KEY}" \
@@ -111,29 +109,8 @@ organisation_create=$( \
 )
 echo ${organisation_create}
 
-echo "Updating organisation_admin to have admin privileges in the department-of-health Organisation:"
-organisation_admin_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=department-of-health&username=organisation_admin&role=admin" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${organisation_admin_update}
-
-echo "Updating publisher to have editor privileges in the department-of-health Organisation:"
-publisher_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=department-of-health&username=editor&role=editor" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${publisher_update}
-
-echo "Updating foodie to have admin privileges in the food-standards-agency Organisation:"
-foodie_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=food-standards-agency&username=foodie&role=admin" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${foodie_update}
+add_user_if_needed group_admin "Group Admin" group_admin@localhost
+add_user_if_needed walker "Walker" walker@localhost
 
 echo "Creating non-organisation group:"
 group_create=$( \
@@ -167,18 +144,8 @@ group_create=$( \
 )
 echo ${group_create}
 
-echo "Creating Dave's Books group:"
-group_create=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"name": "dave", "title": "Dave'"'"'s books", "description": "These are books that David likes."}' \
-    ${CKAN_ACTION_URL}/group_create
-)
-echo ${group_create}
-
-echo "Creating config value for excluded display name words:"
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"ckanext.data_qld.excluded_display_name_words": "gov"}' \
-    ${CKAN_ACTION_URL}/config_option_update
+##
+# END.
+#
 
 . ${APP_DIR}/bin/deactivate

--- a/bin/init-ext.sh
+++ b/bin/init-ext.sh
@@ -2,14 +2,20 @@
 ##
 # Install current extension.
 #
-set -e
-set -x
+set -ex
 
 install_requirements () {
     PROJECT_DIR=$1
     shift
     # Identify the best match requirements file, ignore the others.
-    # If there is one specific to our Python version, use that.
+    # If there is one specific to our CKAN or Python version, use that.
+    for filename_pattern in "$@"; do
+        filename="$PROJECT_DIR/${filename_pattern}-$CKAN_VERSION.txt"
+        if [ -f "$filename" ]; then
+            pip install -r "$filename"
+            return 0
+        fi
+    done
     for filename_pattern in "$@"; do
         filename="$PROJECT_DIR/${filename_pattern}-$PYTHON_VERSION.txt"
         if [ -f "$filename" ]; then
@@ -38,7 +44,5 @@ installed_name=$(grep '^\s*name=' setup.py |sed "s|[^']*'\([-a-zA-Z0-9]*\)'.*|\1
 # Validate that the extension was installed correctly.
 if ! pip list | grep "$installed_name" > /dev/null; then echo "Unable to find the extension in the list"; exit 1; fi
 
-if [ -d "$SRC_DIR/ckan/ckanext/activity" ]; then
-    sed -i 's|^ckan.plugins = |ckan.plugins = activity |' $CKAN_INI
-fi
+. $APP_DIR/bin/process-config.sh
 . ${APP_DIR}/bin/deactivate

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -7,4 +7,3 @@ set -e
 . ${APP_DIR}/bin/activate
 CLICK_ARGS="--yes" ckan_cli db clean
 ckan_cli db init
-ckan_cli db upgrade

--- a/bin/process-config.sh
+++ b/bin/process-config.sh
@@ -1,0 +1,5 @@
+if [ -d "$SRC_DIR/ckan/ckanext/activity" ]; then
+    sed -i 's|^ckan.plugins =|ckan.plugins = activity|' $CKAN_INI
+    sed -i 's|^ckan.plugins =|ckan.plugins = activity|' .docker/test.ini
+fi
+

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -7,8 +7,10 @@ dockerize -wait tcp://redis:6379 -timeout 1m
 
 for i in `seq 1 60`; do
     if (PGPASSWORD=pass psql -h postgres -U ckan_default -d ckan_test -c "\q"); then
+        echo "Database became ready on attempt $i"
         break
     else
+        echo "Database not yet ready, retrying (attempt $i)..."
         sleep 1
     fi
 done

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -11,4 +11,3 @@ $SCRIPT_DIR/test-lint.sh
 $SCRIPT_DIR/test.sh
 
 $SCRIPT_DIR/test-bdd.sh
-

--- a/bin/test-bdd.sh
+++ b/bin/test-bdd.sh
@@ -2,10 +2,7 @@
 ##
 # Run tests in CI.
 #
-set -e
+set -ex
 
-
-echo "==> Run BDD tests"
 ahoy install-site
-ahoy cli "rm -r test/screenshots || true"
-ahoy test-bdd || (echo "run get-logs.sh for container logs if required"; exit 1)
+ahoy test-bdd

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,7 +2,6 @@
 ##
 # Run tests in CI.
 #
-set -e
+set -ex
 
-echo "==> Run Unit tests"
 ahoy test-unit

--- a/ckanext/publications_qld_theme/templates/package/read.html
+++ b/ckanext/publications_qld_theme/templates/package/read.html
@@ -14,3 +14,12 @@
 
 <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="index" />
 {% endblock %}
+
+{% block breadcrumb_content %}
+    {% set index_route_name = 'organization.index' %}
+    {% set org_route_name = 'organization.read' %}
+    <li>{% link_for _('Organizations'), named_route=index_route_name %}</li>
+    <li>{% link_for pkg.organization.title, named_route=org_route_name, id=pkg.organization.name %}</li>
+    {% set dataset_read_route = 'dataset.read' %}
+    <li class="active"><a href="{{ h.url_for(dataset_read_route, id=pkg.name) }}">{{ pkg.title }}</a></li>
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/package/resource_read.html
+++ b/ckanext/publications_qld_theme/templates/package/resource_read.html
@@ -20,6 +20,16 @@
 
 {% block subtitle %}{{ h.resource_display_name(res) }} - {{ h.dataset_display_name(c.package) }}{% endblock %}
 
+{% block breadcrumb_content %}
+    {% set index_route_name = 'organization.index' %}
+    {% set org_route_name = 'organization.read' %}
+    <li>{% link_for _('Organizations'), named_route=index_route_name %}</li>
+    <li>{% link_for pkg.organization.title, named_route=org_route_name, id=pkg.organization.name %}</li>
+    {% set dataset_read_route = 'dataset.read' %}
+    <li class="active"><a href="{{ h.url_for(dataset_read_route, id=pkg.name) }}">{{ pkg.title }}</a></li>
+    <li class="active"><a href="">{{ h.resource_display_name(res) }}</a></li>
+{% endblock %}
+
 {% block pre_primary %}
 {% endblock %}
 

--- a/ckanext/publications_qld_theme/templates/package/snippets/resources.html
+++ b/ckanext/publications_qld_theme/templates/package/snippets/resources.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block resources_list %}
+  <ul class="list-unstyled nav nav-simple">
+    {% for resource in resources %}
+      <li class="nav-item{{ ' active' if active == resource.id }}">
+        <a href="{{ h.url_for('%s_resource.%s' % (pkg.type, (action or 'read')), id=pkg.name, resource_id=resource.id, inner_span=true) }}" title="{{ h.resource_display_name(resource) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/snippets/package_list.html
+++ b/ckanext/publications_qld_theme/templates/snippets/package_list.html
@@ -6,7 +6,7 @@ list_class     - The class name for the list item.
 item_class     - The class name to use on each item.
 hide_resources - If true hides the resources (default: false).
 banner         - If true displays a popular banner (default: false).
-truncate       - The length to trucate the description to (default: 180)
+truncate       - The length to truncate the description to (default: 180)
 truncate_title - The length to truncate the title to (default: 80).
 
 Example:

--- a/test/features/config.feature
+++ b/test/features/config.feature
@@ -3,7 +3,8 @@ Feature: Config
 
     Scenario: Assert that configuration values are customised
         Given "SysAdmin" as the persona
-        When I log in and go to admin config page
+        When I log in
+        And I go to admin config page
         Then I should see "Intro Text"
         And I should see "Excluded display name words:"
         And I should see an element with xpath "//textarea[@id='field-ckanext.data_qld.excluded_display_name_words' and contains(string(), 'gov')]"

--- a/test/features/data_qld_theme.feature
+++ b/test/features/data_qld_theme.feature
@@ -1,6 +1,18 @@
 Feature: Theme customisations
 
     @unauthenticated
+    Scenario: As a member of the public, when I go to the consistent asset URLs, I can see the asset
+        Given "Unauthenticated" as the persona
+        When I visit "/assets/css/main"
+        Then I should see "Bootstrap"
+        When I visit "/assets/css/font-awesome"
+        Then I should see "Font Awesome"
+        When I visit "/assets/css/select2"
+        Then I should see "select2-container"
+        When I visit "/assets/js/jquery"
+        Then I should see "jQuery"
+
+    @unauthenticated
     Scenario: Lato font is implemented on homepage
         Given "Unauthenticated" as the persona
         When I go to homepage
@@ -17,7 +29,7 @@ Feature: Theme customisations
         Given "SysAdmin" as the persona
         When I log in
         And I go to organisation page
-        And I click the link with text that contains "Add Organisation"
+        And I press "Add Organisation"
         Then I should see "Create an Organisation"
         When I execute the script "$('#field-name').val('Org without description')"
         And I execute the script "$('#field-url').val('org-without-description')"
@@ -30,7 +42,7 @@ Feature: Theme customisations
         Given "SysAdmin" as the persona
         When I log in
         And I go to organisation page
-        And I click the link with text that contains "Add Organisation"
+        And I press "Add Organisation"
         Then I should see "Create an Organisation"
         When I execute the script "$('#field-name').val('Org with description')"
         And I execute the script "$('#field-url').val('org-with-description')"
@@ -44,16 +56,17 @@ Feature: Theme customisations
     @unauthenticated
     Scenario: Explore button does not exist on dataset detail page
         Given "Unauthenticated" as the persona
-        When I go to dataset page
-        And I click the link with text that contains "public-test"
+        When I go to dataset "public-test-dataset"
         Then I should not see "Explore"
 
     @unauthenticated
-    Scenario: Explore button does not exist on dataset detail page
+    Scenario: As a member of the public, I should be able to see the help text on the organisation page
+        Given "Unauthenticated" as the persona
         When I go to organisation page
         Then I should see "Organisations are Queensland Government departments, other agencies or legislative entities responsible for publishing open data on this portal."
 
     Scenario: Register user password must be 10 characters or longer
+        Given "Unauthenticated" as the persona
         When I go to register page
         And I fill in "name" with "name"
         And I fill in "fullname" with "fullname"
@@ -64,6 +77,7 @@ Feature: Theme customisations
         Then I should see "Password: Your password must be 10 characters or longer"
 
     Scenario: Register user password must contain at least one number, lowercase letter, capital letter, and symbol
+        Given "Unauthenticated" as the persona
         When I go to register page
         And I fill in "name" with "name"
         And I fill in "fullname" with "fullname"
@@ -73,7 +87,10 @@ Feature: Theme customisations
         And I press "Create Account"
         Then I should see "Password: Must contain at least one number, lowercase letter, capital letter, and symbol"
 
-    Scenario: Menu items are present and correct
+    @unauthenticated
+    @Publications
+    Scenario: Publications - Menu items are present and correct
+        Given "Unauthenticated" as the persona
         When I go to "/dataset"
         Then I should see an element with xpath "//li[contains(@class, 'active')]/a[contains(string(), 'Publication') and (@href='/dataset' or @href='/dataset/')]"
         And I should see an element with xpath "//li[not(contains(@class, 'active'))]/a[contains(string(), 'Standards') and @href='/dataset/publishing-standards-publications-qld-gov-au']"

--- a/test/features/dataset_deletion.feature
+++ b/test/features/dataset_deletion.feature
@@ -4,16 +4,14 @@ Feature: Dataset deletion
     Scenario: Sysadmin creates and deletes a dataset
         Given "SysAdmin" as the persona
         When I log in
-        And I create a dataset with name "dataset-deletion" and title "Dataset deletion"
-        And I wait for 10 seconds
-        Then I should see "Data and Resources"
-
-        When I edit the "dataset-deletion" dataset
-        Then I press the element with xpath "//a[string()='Delete' and @data-module='confirm-action']"
-        Then I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Confirm')]"
-        And I wait for 5 seconds
-        Then I should see "Dataset has been deleted"
-        And I should not see "Dataset deletion"
+        And I create a dataset and resource with key-value parameters "notes=Testing dataset deletion" and "url=default"
+        And I edit the "$last_generated_name" dataset
+        When I press the element with xpath "//a[@data-module='confirm-action']"
+        And I confirm dataset deletion
+        And I reload page every 2 seconds until I see an element with xpath "//div[contains(@class, "alert") and contains(string(), "Dataset has been deleted")]" but not more than 5 times
+        Then I should not see an element with xpath "//a[contains(@href, '/dataset/$last_generated_name')]"
         When I go to "/ckan-admin/trash"
-        Then I should see "Dataset deletion"
-        Then I press the element with xpath "//form[contains(@id, 'form-purge-package')]//*[contains(text(), 'Purge')]"
+        Then I should see an element with xpath "//a[contains(@href, '/dataset/$last_generated_name')]"
+        When I press the element with xpath "//form[contains(@id, 'form-purge-package')]//*[contains(string(), 'Purge')]"
+        And I confirm the dialog containing "Are you sure you want to purge datasets?" if present
+        Then I should see "datasets have been purged"

--- a/test/features/datasets.feature
+++ b/test/features/datasets.feature
@@ -14,17 +14,11 @@ Feature: Dataset APIs
         And I press the element with xpath "//form[@id='dataset-edit']//button[contains(@class, 'btn-primary')]"
         And I press the element with xpath "//a[contains(@href, '/dataset/activity/') and contains(string(), 'Activity Stream')]"
         Then I should see "created the dataset"
-        When I click the link with text that contains "View this version"
+        When I press "View this version"
         Then I should see "You're currently viewing an old version of this dataset."
         When I go to dataset "public-test-dataset"
         And I press the element with xpath "//a[contains(@href, '/dataset/activity/') and contains(string(), 'Activity Stream')]"
-        And I click the link with text that contains "Changes"
+        And I press "Changes"
         Then I should see "View changes from"
         And I should see an element with xpath "//select[@name='old_id']"
         And I should see an element with xpath "//select[@name='new_id']"
-
-    Scenario: As a user with publishing privileges, I can create a dataset
-        Given "TestOrgEditor" as the persona
-        When I log in
-        And I create a dataset with name "testing-dataset-creation" and title "Testing dataset creation"
-        Then I should see "Testing dataset creation"

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,7 +1,9 @@
+# encoding: utf-8
+
 import os
 
 from behaving import environment as benv
-from behaving.web.steps.browser import named_browser
+from splinter.browser import Browser
 
 # Path to the root of the project.
 ROOT_PATH = os.path.realpath(os.path.join(
@@ -26,12 +28,6 @@ PERSONAS = {
         'email': u'',
         'password': u''
     },
-    # This user will not be assigned to any organisations
-    'CKANUser': {
-        'name': u'ckan_user',
-        'email': u'ckan_user@localhost',
-        'password': u'Password123!'
-    },
     'Organisation Admin': {
         'name': u'organisation_admin',
         'email': u'organisation_admin@localhost',
@@ -50,6 +46,12 @@ PERSONAS = {
     'Walker': {
         'name': u'walker',
         'email': u'walker@localhost',
+        'password': u'Password123!'
+    },
+    # This user will not be assigned to any organisations
+    'CKANUser': {
+        'name': u'ckan_user',
+        'email': u'ckan_user@localhost',
         'password': u'Password123!'
     },
     'Foodie': {
@@ -86,11 +88,6 @@ def before_all(context):
     # Set base url for all relative links.
     context.base_url = BASE_URL
 
-    # Always use remote web driver.
-    context.remote_webdriver = 1
-    context.default_browser = 'chrome'
-    context.browser_args = {'command_executor': REMOTE_CHROME_URL}
-
     # Set the rest of the settings to default Behaving's settings.
     benv.before_all(context)
 
@@ -110,7 +107,12 @@ def after_feature(context, feature):
 def before_scenario(context, scenario):
     benv.before_scenario(context, scenario)
     # Always use remote browser.
-    named_browser(context, 'remote')
+    remote_browser = Browser(
+        driver_name="remote", browser="chrome",
+        command_executor=REMOTE_CHROME_URL
+    )
+    for persona_name in PERSONAS.keys():
+        context.browsers[persona_name] = remote_browser
     # Set personas.
     context.personas = PERSONAS
 

--- a/test/features/google_analytics.feature
+++ b/test/features/google_analytics.feature
@@ -1,4 +1,4 @@
-@google-analytics
+@google_analytics
 Feature: GoogleAnalytics
 
     @unauthenticated
@@ -11,7 +11,7 @@ Feature: GoogleAnalytics
     Scenario: When viewing the HTML source code of a group, the appropriate metadata is visible
         Given "Unauthenticated" as the persona
         When I go to group page
-        And I resize the browser to 1024x2048
+        And I expand the browser height
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Groups']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
@@ -20,13 +20,13 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
-        When I click the link with text that contains "Dave's books"
-        And I click the link with text that contains "About"
-        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and contains(@content, 'Dave')]"
+        When I press "Silly walks"
+        And I press "About"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and contains(@content, 'Silly walks')]"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and contains(@content, 'c=AU; o=The State of Queensland; ou=Dave') and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and contains(@content, 'c=AU; o=The State of Queensland; ou=Silly walks') and @scheme='AGLSTERMS.GOLD']"
         And I should see an element with xpath "//meta[@name='DCTERMS.created' and @content!='' and @content!='None']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='These are books that David likes.']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='The Ministry of Silly Walks']"
         And I should see an element with xpath "//meta[@name='DCTERMS.identifier' and @content!='' and @content!='None']"
         And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
@@ -36,7 +36,7 @@ Feature: GoogleAnalytics
     Scenario: When viewing the HTML source code of an organisation, the appropriate metadata is visible
         Given "Unauthenticated" as the persona
         When I go to organisation page
-        And I resize the browser to 1024x2048
+        And I expand the browser height
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Organisations']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
@@ -45,13 +45,13 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
-        When I click the link with text that contains "Department of Health"
-        And I click the link with text that contains "About"
-        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Department of Health']"
+        When I press "Test Organisation"
+        And I press "About"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Test Organisation']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Department of Health' and @scheme='AGLSTERMS.GOLD']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Test Organisation' and @scheme='AGLSTERMS.GOLD']"
         And I should see an element with xpath "//meta[@name='DCTERMS.created' and @content!='' and @content!='None']"
-        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='Department of Health']"
+        And I should see an element with xpath "//meta[@name='DCTERMS.description' and @content='Organisation for testing issues']"
         And I should see an element with xpath "//meta[@name='DCTERMS.identifier' and @content!='' and @content!='None']"
         And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
@@ -60,7 +60,7 @@ Feature: GoogleAnalytics
     Scenario: When viewing the HTML source code of a resource, the appropriate metadata is visible
         Given "TestOrgEditor" as the persona
         When I go to Dataset page
-        And I resize the browser to 1024x2048
+        And I expand the browser height
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Datasets']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland;' and @scheme='AGLSTERMS.GOLD']"
@@ -70,7 +70,7 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
         When I log in
-        And I create a dataset with name "dcterms-testing" and title "DCTERMS testing"
+        And I create a dataset and resource with key-value parameters "name=dcterms-testing::title=DCTERMS testing" and "url=default"
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='DCTERMS testing']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Test Organisation' and @scheme='AGLSTERMS.GOLD']"
@@ -82,7 +82,7 @@ Feature: GoogleAnalytics
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//meta[@name='AGLSTERMS.documentType' and @content='index']"
 
-        When I click the link with text that contains "Test Resource"
+        When I press "Test Resource"
         Then I should see an element with xpath "//meta[@name='DCTERMS.title' and @content='Test Resource']"
         And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.creator' and @content='c=AU; o=The State of Queensland; ou=Test Organisation' and @scheme='AGLSTERMS.GOLD']"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -19,9 +19,9 @@ Feature: Group APIs
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
 
         Examples: Non-admin users
-            | Persona             |
-            | Organisation Admin  |
-            | Walker              |
+            | Persona       |
+            | TestOrgAdmin  |
+            | Walker        |
 
     @unauthenticated
     Scenario: Group membership is not accessible anonymously
@@ -33,7 +33,7 @@ Feature: Group APIs
     Scenario: Group overview is accessible to everyone
         Given "Unauthenticated" as the persona
         When I go to "/group"
-        Then I should see "silly-walks"
+        Then I should see "Silly walks"
         And I should not see an element with xpath "//a[contains(@href, '?action=read')]"
         And I should see an element with xpath "//a[contains(@href, '/group/silly-walks')]"
 

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -11,18 +11,3 @@ Feature: Homepage
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"
         And I should see an element with xpath "//a[@href='https://www.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/queensland-government-gazette/publish-in-the-gazette' and string()='Publish in the Gazettes']"
 
-
-    @homepage
-    @unauthenticated
-    Scenario: As a member of the public, when I go to the consistent asset URLs, I can see the asset
-        Given "Unauthenticated" as the persona
-        When I visit "/assets/css/main"
-        Then I should see "Bootstrap"
-        When I visit "/assets/css/font-awesome"
-        Then I should see "Font Awesome"
-        When I visit "/assets/css/select2"
-        Then I should see "select2-container"
-        When I visit "/assets/js/jquery"
-        Then I should see "jQuery"
-        When I visit "/assets/js/bootstrap"
-        Then I should see "Bootstrap"

--- a/test/features/login.feature
+++ b/test/features/login.feature
@@ -4,6 +4,6 @@ Feature: Login
     Scenario: Smoke test to ensure Login step works
         Given "SysAdmin" as the persona
         When I log in
-        And I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
+        Then I should see an element with xpath "//meta[@name='DCTERMS.publisher' and @content='corporateName=The State of Queensland; jurisdiction=Queensland' and @scheme='AGLSTERMS.AglsAgent']"
         And I should see an element with xpath "//meta[@name='DCTERMS.jurisdiction' and @content='Queensland' and @scheme='AGLSTERMS.AglsJuri']"
         And I should see an element with xpath "//meta[@name='DCTERMS.type' and @content='Text' and @scheme='DCTERMS.DCMIType']"

--- a/test/features/login_redirect.feature
+++ b/test/features/login_redirect.feature
@@ -21,21 +21,21 @@ Feature: Login Redirection
     @unauthenticated
     Scenario: As an unauthenticated user, when I visit the URL of a private dataset I see the login page
         Given "Unauthenticated" as the persona
-        When I visit "/dataset/test-dataset"
+        When I go to dataset "test-dataset"
         Then I should see the login form
 
     @public_dataset
     @unauthenticated
     Scenario: As an unauthenticated user, when I visit the URL of a public dataset I see the dataset without needing to login
         Given "Unauthenticated" as the persona
-        When I visit "/dataset/public-test-dataset"
+        When I go to dataset "public-test-dataset"
         Then I should see "public test"
         And I should not see an element with xpath "//h1[contains(string(), 'Login')]"
 
     @private_dataset
     Scenario: As an unauthenticated organisation member, when I visit the URL of a private dataset I see the login page. Upon logging in I am taken to the private dataset
         Given "TestOrgMember" as the persona
-        When I visit "/dataset/test-dataset"
+        When I go to dataset "test-dataset"
         Then I should see the login form
         When I log in directly
         Then I should see "private test"
@@ -45,6 +45,6 @@ Feature: Login Redirection
     Scenario: As an authenticated organisation member, when I visit the URL of a dataset private to my organisation I am taken to the private dataset
         Given "TestOrgMember" as the persona
         When I log in
-        Then I visit "/dataset/test-dataset"
+        And I go to dataset "test-dataset"
         Then I should see an element with xpath "//h1[contains(string(), 'test-dataset')]"
         And I should see an element with xpath "//span[contains(string(), 'Private')]"

--- a/test/features/organisations.feature
+++ b/test/features/organisations.feature
@@ -4,39 +4,39 @@ Feature: Organization APIs
     Scenario Outline: Organisation membership is accessible to admins of the organisation
         Given "<Persona>" as the persona
         When I log in
-        And I view the "department-of-health" organisation API "including" users
-        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "organisation_admin"') and contains(string(), '"name": "editor"')]"
+        And I view the "test-organisation" organisation API "including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "test_org_admin"') and contains(string(), '"name": "test_org_editor"')]"
 
         Examples: Admins
-            | Persona             |
-            | SysAdmin            |
-            | Organisation Admin  |
+            | Persona       |
+            | SysAdmin      |
+            | TestOrgAdmin  |
 
     Scenario Outline: Organisation membership is not accessible to non-admins
         Given "<Persona>" as the persona
         When I log in
-        And I view the "department-of-health" organisation API "including" users
+        And I view the "test-organisation" organisation API "including" users
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
 
         Examples: Non-admin users
             | Persona       |
-            | Publisher     |
-            | Walker        |
+            | TestOrgEditor |
+            | TestOrgMember |
             | Group Admin   |
 
     @unauthenticated
     Scenario: Organisation membership is not accessible anonymously
         Given "Unauthenticated" as the persona
-        When I view the "department-of-health" organisation API "including" users
+        When I view the "test-organisation" organisation API "including" users
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
 
     @unauthenticated
     Scenario: Organisation overview is accessible to everyone
         Given "Unauthenticated" as the persona
         When I go to organisation page
-        Then I should see "Department of Health"
+        Then I should see "Test Organisation"
         And I should not see an element with xpath "//a[contains(@href, '?action=read')]"
-        And I should see an element with xpath "//a[contains(@href, '/organization/department-of-health')]"
+        And I should see an element with xpath "//a[contains(@href, '/organization/test-organisation')]"
 
-        When I view the "department-of-health" organisation API "not including" users
-        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "department-of-health"')]"
+        When I view the "test-organisation" organisation API "not including" users
+        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "test-organisation"')]"

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -3,7 +3,9 @@ Feature: Resource UI
 
     Scenario Outline: Link resource should create a link to its URL
         Given "SysAdmin" as the persona
-        When I create a resource with name "<name>" and URL "<url>"
+        When I log in
+        And I open the new resource form for dataset "test-dataset"
+        And I create a resource with key-value parameters "name=<name>::url=<url>"
         And I press the element with xpath "//a[contains(@title, '<name>') and contains(string(), '<name>')]"
         Then I should see "<url>"
 
@@ -12,11 +14,26 @@ Feature: Resource UI
         | Good link | http://www.qld.gov.au |
         | Good IP address | http://1.2.3.4 |
         | Domain starting with numbers | http://1.2.3.4.example.com |
-        | Domain ending with numbers | http://example.com.1.2.3.4 |
+        # chrome url type input treats it as invalid one
+        # | Domain ending with numbers | http://example.com.1.2.3.4 |
         | Domain ending with private | http://example.com.private |
+
+    Scenario: As a publisher, when I create a resource with a long name, it should be preserved
+        Given "TestOrgEditor" as the persona
+        When I log in
+        And I create a dataset and resource with key-value parameters "title=More than 30 characters aaaaaaaaaaaa" and "name=More than 30 characters bbbbbbbbbbbb"
+        # Breadcrumbs should not be truncated
+        Then I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(string(), 'More than 30 characters aaaaaaaaaaaa')]"
+        And I should see "More than 30 characters bbbbbbbbbbbb"
+        When I press "More than 30 characters bbbbbbbbbbbb"
+        Then I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(string(), 'More than 30 characters aaaaaaaaaaaa')]"
+        And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(string(), 'More than 30 characters bbbbbbbbbbbb')]"
+        # Sidebar resource nav truncates but preserves full name in a tooltip
+        And I should see an element with xpath "//li[contains(@class, 'nav-item')]//a[contains(string(), 'More than 30') and contains(string(), '...') and @title = 'More than 30 characters bbbbbbbbbbbb']"
 
     Scenario: Link resource with missing or invalid protocol should use HTTP
         Given "SysAdmin" as the persona
-        When I create a resource with name "Non-HTTP link" and URL "git+https://github.com/ckan/ckan.git"
-        And I press the element with xpath "//a[contains(@title, 'Non-HTTP link') and contains(string(), 'Non-HTTP link')]"
-        And I should see "http://git+https://github.com/ckan/ckan.git"
+        When I log in
+        And I create a dataset and resource with key-value parameters "title=Non-HTTP resource" and "name=Non-HTTP link::url=git+https://github.com/ckan/ckan.git"
+        And I press "Non-HTTP link"
+        Then I should see "http://git+https://github.com/ckan/ckan.git"

--- a/test/features/user_creation.feature
+++ b/test/features/user_creation.feature
@@ -4,9 +4,9 @@ Feature: User creation
     Scenario: SysAdmin can create 'Excluded display name words' in ckan admin config
         Given "SysAdmin" as the persona
         When I log in
-        Then I go to "/ckan-admin/config"
+        And I go to "/ckan-admin/config"
         Then I should see "Excluded display name words"
-        Then I fill in "ckanext.data_qld.excluded_display_name_words" with "gov"
+        When I fill in "ckanext.data_qld.excluded_display_name_words" with "gov"
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
 
     Scenario: SysAdmin create a new user to the site.
@@ -15,20 +15,19 @@ Feature: User creation
         When I go to "/user/register"
         Then I should see an element with xpath "//input[@name='fullname']"
         And I should see "Displayed name"
-        Then I fill in "name" with "publisher_user"
-        Then I fill in "fullname" with "gov user"
+        When I fill in "name" with "publisher_user"
+        And I fill in "fullname" with "gov user"
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
-        And I wait for 10 seconds
         Then I should not see "The username cannot contain the word 'publisher'. Please enter another username."
-        Then I should not see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."
+        And I should not see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."
 
     Scenario: Non logged-in user register to the site.
+        Given "Unauthenticated" as the persona
         When I go to register page
         Then I should see an element with xpath "//input[@name='fullname']"
         And I should see "Displayed name"
-        Then I fill in "name" with "publisher_user"
-        Then I fill in "fullname" with "gov user"
+        When I fill in "name" with "publisher_user"
+        And I fill in "fullname" with "gov user"
         And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
-        And I wait for 10 seconds
         Then I should see "The username cannot contain the word 'publisher'. Please enter another username."
-        Then I should see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."
+        And I should see "The displayed name cannot contain certain words such as 'publisher', 'QLD Government' or similar. Please enter another display name."

--- a/test/features/users.feature
+++ b/test/features/users.feature
@@ -14,7 +14,7 @@ Feature: User APIs
             | Group Admin   |
 
     Scenario: User autocomplete is not accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
         And I search the autocomplete API for user "admin"
         Then I should see an element with xpath "//body//div[contains(string(), 'Internal server error')]"
@@ -40,7 +40,7 @@ Feature: User APIs
             | Group Admin   |
 
     Scenario: User list is not accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
         And I go to the user list API
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
@@ -64,13 +64,13 @@ Feature: User APIs
             | Group Admin   |
 
     Scenario: User detail for self is accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
-        And I go to the "editor" user API
-        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "editor"')]"
+        And I go to the "test_org_member" user API
+        Then I should see an element with xpath "//*[contains(string(), '"success": true') and contains(string(), '"name": "test_org_member"')]"
 
     Scenario: Non-self user detail is not accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I go to the "admin" user API
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
@@ -78,7 +78,7 @@ Feature: User APIs
     @unauthenticated
     Scenario: User detail is not accessible anonymously
         Given "Unauthenticated" as the persona
-        When I go to the "editor" user API
+        When I go to the "test_org_member" user API
         Then I should see an element with xpath "//*[contains(string(), '"success": false') and contains(string(), 'Authorization Error')]"
 
     Scenario Outline: User profile page is accessible to admins
@@ -94,13 +94,13 @@ Feature: User APIs
             | Group Admin   |
 
     Scenario: User profile page for self is accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
-        And I go to the "editor" profile page
-        Then I should see an element with xpath "//h1[string() = 'Publisher']"
+        And I go to the "test_org_member" profile page
+        Then I should see an element with xpath "//h1[string() = 'Test Member']"
 
     Scenario: Non-self user profile page is not accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
         And I go to the "admin" profile page
         Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
@@ -108,11 +108,11 @@ Feature: User APIs
     @unauthenticated
     Scenario: User profile page is not accessible anonymously
         Given "Unauthenticated" as the persona
-        When I go to the "editor" profile page
+        When I go to the "test_org_member" profile page
         Then I should see an element with xpath "//*[contains(string(), 'Not authorised to see this page')]"
 
     Scenario: Dashboard page is accessible to non-admins
-        Given "Publisher" as the persona
+        Given "TestOrgEditor" as the persona
         When I log in
         And I go to the dashboard
         Then I should see my datasets
@@ -120,7 +120,7 @@ Feature: User APIs
 
     @email
     Scenario: As a registered user, when I have locked my account with too many failed logins, I can reset my password to unlock it
-        Given "Foodie" as the persona
+        Given "CKANUser" as the persona
         When I lock my account
         And I go to "/user/login"
         And I attempt to log in with password "$password"
@@ -136,9 +136,11 @@ Feature: User APIs
         When I fill in "password1" with "$password"
         And I fill in "password2" with "$password"
         And I press the element with xpath "//button[@class='btn btn-primary']"
-        Then I log in
+        When I log in
+        Then I should see "Dashboard"
 
     Scenario: Register user password must be 10 characters or longer and contain number, lowercase, capital, and symbol
+        Given "Unauthenticated" as the persona
         When I go to register page
         And I fill in "name" with "name"
         And I fill in "fullname" with "fullname"
@@ -147,7 +149,7 @@ Feature: User APIs
         And I fill in "password2" with "pass"
         And I press "Create Account"
         Then I should see "Password: Your password must be 10 characters or longer"
-        Then I fill in "password1" with "password1234"
+        When I fill in "password1" with "password1234"
         And I fill in "password2" with "password1234"
         And I press "Create Account"
         Then I should see "Password: Must contain at least one number, lowercase letter, capital letter, and symbol"


### PR DESCRIPTION
- Don't truncate breadcrumbs.
- Add tooltips to the resource nav sidebar links, to preserve the full names.