### PR TITLE
[QOLDEV-640] apply link styling to header buttons with the 'btn-link' class

### DIFF
--- a/ckanext/publications_qld_theme/assets/publications_qld.css
+++ b/ckanext/publications_qld_theme/assets/publications_qld.css
@@ -311,7 +311,8 @@ div.account-masthead .account ul.list-unstyled li {
   border: none;
 }
 
-div.account-masthead .account ul.list-unstyled li a {
+div.account-masthead .account ul.list-unstyled li a,
+div.account-masthead .account ul.list-unstyled li .btn-link {
   color: #ffffff;
   text-decoration: none;
   line-height: 1rem;
@@ -334,7 +335,9 @@ div.account-masthead .account ul.list-unstyled li a {
 }
 
 div.account-masthead .account ul.list-unstyled li a:hover,
-div.account-masthead .account ul.list-unstyled li a:focus {
+div.account-masthead .account ul.list-unstyled li a:focus,
+div.account-masthead .account ul.list-unstyled li .btn-link:hover,
+div.account-masthead .account ul.list-unstyled li .btn-link:focus {
   color: #ffffff;
   background-color: #007eb1;
 }


### PR DESCRIPTION
CKAN core developers are looking at changing the logout link into a button (see https://github.com/ckan/ckan/pull/7892), so we should adjust our styling to include that.