### PR TITLE
[QOLDEV-2051] don't turn white links purple on visit

### DIFF
--- a/ckanext/publications_qld_theme/assets/publications_qld.css
+++ b/ckanext/publications_qld_theme/assets/publications_qld.css
@@ -525,6 +525,11 @@ nav.sort-content button {
     /* Close buttons inside a dismissable alert aren't properly handled by QGDS yet */
     height: 1rem;
     top: 0px;
+    right: 0px;
+}
+.badge {
+    /* Don't turn white links purple when visited (white links imply a dark background) */
+    color: var(--qld-badge-color) !important;
 }
 
 li.nav-item a span.badge {


### PR DESCRIPTION
- If a link was white, then the background is implied to be dark, so purple is a poor colour choice