### PR TITLE
[QOLDEV-2051] drop underline offset from badges

### DIFF
--- a/ckanext/publications_qld_theme/assets/publications_qld.css
+++ b/ckanext/publications_qld_theme/assets/publications_qld.css
@@ -502,6 +502,7 @@ a .fa::before, a .fa-solid::before, a .fa-stack::before, a .fa-brands::before {
     /* Handle page numbers above 2 digits */
     width: unset;
     min-width: 2rem;
+    padding: 0 0.7rem 0 0.7rem;
 }
 nav.sort-content button {
     /* Sort order buttons aren't laid out like form buttons */

--- a/ckanext/publications_qld_theme/assets/publications_qld.css
+++ b/ckanext/publications_qld_theme/assets/publications_qld.css
@@ -527,9 +527,10 @@ nav.sort-content button {
     top: 0px;
     right: 0px;
 }
-.badge {
+a.badge {
     /* Don't turn white links purple when visited (white links imply a dark background) */
-    color: var(--qld-badge-color) !important;
+    color: var(--qld-badge-color);
+    text-underline-offset: unset;
 }
 
 li.nav-item a span.badge {


### PR DESCRIPTION
- There isn't room on our badges for the large underline spacing that other links have