### PR TITLE
QOLDEV-2051 add QGDS Bootstrap script

### DIFF
--- a/ckanext/publications_qld_theme/templates/base.html
+++ b/ckanext/publications_qld_theme/templates/base.html
@@ -11,11 +11,11 @@
 {% endblock %}
 
 {% block custom_styles %}
+  {{ super() }}
   <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" />
   <link href="{{ h.set_external_resources() }}/__data/assets/git_bridge/0019/100846/open-data/dist/qld.css?h=eeb329b" rel="stylesheet" />
   <link href="https://static.qgov.net.au/qgds-bootstrap5/v2/v2.2.1/assets/css/qld.bootstrap.css" rel="stylesheet" />
-  {% set type = 'asset' %}
-  {% include 'snippets/publications_qld_' ~ type ~ '.html' %}
+  {% include 'snippets/publications_qld_asset.html' %}
 {% endblock %}
 
 {% block scripts %}

--- a/ckanext/publications_qld_theme/templates/base.html
+++ b/ckanext/publications_qld_theme/templates/base.html
@@ -17,3 +17,8 @@
   {% set type = 'asset' %}
   {% include 'snippets/publications_qld_' ~ type ~ '.html' %}
 {% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="https://static.qgov.net.au/qgds-bootstrap5/v2/v2.2.1/assets/js/qld.bootstrap.min.js" defer></script>
+{% endblock %}

--- a/ckanext/publications_qld_theme/templates/header.html
+++ b/ckanext/publications_qld_theme/templates/header.html
@@ -116,7 +116,7 @@
                 <div class="col-lg-4">
                   {% block header_site_search %}
                     <div id="qld-header-search" class="qld-header-site-search is-closed">
-                      <form class="site-search" role="search" action="{% url_for dataset_type ~ '.search' %}" method="get">
+                      <form role="search" action="{% url_for dataset_type ~ '.search' %}" method="get">
                         <!--
                             QGDS Component: Search input
                         -->

--- a/ckanext/publications_qld_theme/templates/home/index.html
+++ b/ckanext/publications_qld_theme/templates/home/index.html
@@ -21,7 +21,7 @@
 
                     <div class="banner-cta" role="group">
                         <div class="cta-buttons">
-                            <form class="site-search w-100" action="/dataset" method="get" autocomplete="off">
+                            <form class="w-100" action="/dataset" method="get" autocomplete="off">
                                 <div class="qld-search-input full-width">
                                     <input class="form-control" type="text" name="q" aria-label="Search Publications">
                                     <button class="btn btn-primary" type="submit">


### PR DESCRIPTION
- This fixes the mobile search button
- Drop 'site-search' class from our search form so that the bootstrap script won't inject Funnelback-specific parameters